### PR TITLE
Use Release config for CodeQL to skip preview dylib

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Run manual build steps
       if: matrix.build-mode == 'manual'
       shell: bash
-      run: scripts/generate.sh && scripts/compile.sh
+      run: scripts/generate.sh && scripts/compile.sh -configuration Release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -11,7 +11,7 @@ run_xcodebuild \
   -scheme "$SCHEME" \
   -destination "platform=iOS Simulator,name=$SIMULATOR" \
   -configuration Debug \
-  ENABLE_PREVIEWS=NO \
+  "$@" \
   build
 
 echo "==> Done."


### PR DESCRIPTION
## Summary
- `ENABLE_PREVIEWS=NO` doesn't actually suppress `__preview.dylib` — that's an IDE-only flag
- Release configuration is what truly prevents the preview dylib from being generated
- `compile.sh` now forwards extra CLI args via `"$@"` so the workflow can pass `-configuration Release` without affecting local Debug builds

## Test plan
- [ ] Verify `__preview.dylib` no longer appears in the CodeQL build log
- [ ] Verify overall CodeQL run time is significantly shorter

🤖 Generated with [Claude Code](https://claude.com/claude-code)