### PR TITLE
Fix duplicate -configuration flag (exit code 64)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Run manual build steps
       if: matrix.build-mode == 'manual'
       shell: bash
-      run: scripts/generate.sh && scripts/compile.sh -configuration Release
+      run: scripts/generate.sh && CONFIGURATION=Release scripts/compile.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -5,13 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/common.sh
 source "$SCRIPT_DIR/common.sh"
 
+CONFIGURATION="${CONFIGURATION:-Debug}"
+
 echo "==> Building $SCHEME..."
 run_xcodebuild \
   -project "$PROJECT" \
   -scheme "$SCHEME" \
   -destination "platform=iOS Simulator,name=$SIMULATOR" \
-  -configuration Debug \
-  "$@" \
+  -configuration "$CONFIGURATION" \
   build
 
 echo "==> Done."


### PR DESCRIPTION
## Summary
- Passing `-configuration Release` via `"$@"` after the hardcoded `-configuration Debug` gave xcodebuild two conflicting flags, causing exit code 64
- Replaced with a `CONFIGURATION` env var (default: `Debug`); CodeQL workflow sets `CONFIGURATION=Release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)