### PR TITLE
feat: armored brick — tiered crack overlays and silver plate

### DIFF
--- a/Sources/Constants/Theme.swift
+++ b/Sources/Constants/Theme.swift
@@ -41,6 +41,8 @@ enum Theme {
         static let indestructible: PlatformColor = PlatformColor(white: 0.3, alpha: 1.0)
         static let indestructibleBorder: PlatformColor =
             PlatformColor(red: 0.0, green: 0.95, blue: 1.0, alpha: 0.7)
+        // Briques armored (multiHit) — plaque argentée
+        static let armored: PlatformColor = PlatformColor(white: 0.72, alpha: 1.0)
         static let brickColors: [PlatformColor] = [
             PlatformColor(red: 1.0, green: 0.35, blue: 0.35, alpha: 1), // coral-red
             PlatformColor(red: 1.0, green: 0.6, blue: 0.1, alpha: 1), // orange

--- a/Sources/Nodes/BrickNode.swift
+++ b/Sources/Nodes/BrickNode.swift
@@ -9,6 +9,9 @@ final class BrickNode: SKSpriteNode {
     private let initialHits: Int
     private var hitHandled = false
 
+    // Briques armored = multiHit avec au moins 2 coups requis
+    private var isArmored: Bool { !isIndestructible && !isBonus && initialHits >= 2 }
+
     var currentCell: BrickCell {
         if isIndestructible { return .indestructible }
         // Only report .bonus while intact; destroyed falls through to .empty via brickState.asCell
@@ -26,9 +29,17 @@ final class BrickNode: SKSpriteNode {
         case .intact(let n): self.initialHits = n
         case .destroyed: self.initialHits = 1
         }
-        let rowColor = isIndestructible
-            ? Theme.Color.indestructible
-            : Theme.Color.brickColors[row % Theme.Color.brickColors.count]
+        // Briques multiHit affichent une plaque argentée plutôt qu'une couleur par rang
+        let isMultiHitCell: Bool
+        if case .multiHit = cell { isMultiHitCell = true } else { isMultiHitCell = false }
+        let rowColor: PlatformColor
+        if isIndestructible {
+            rowColor = Theme.Color.indestructible
+        } else if isMultiHitCell {
+            rowColor = Theme.Color.armored
+        } else {
+            rowColor = Theme.Color.brickColors[row % Theme.Color.brickColors.count]
+        }
         super.init(texture: nil, color: rowColor, size: size)
         addChild(ShadowNode.makeBrickShadow(size: size, color: rowColor))
         let body = SKPhysicsBody(rectangleOf: size)
@@ -40,14 +51,18 @@ final class BrickNode: SKSpriteNode {
         physicsBody = body
 
         if case .multiHit(let n) = cell {
+            // Label secondaire positionné en bas à droite — l'overlay de fissures est le visuel principal
             let label = SKLabelNode(fontNamed: Theme.Font.bold)
             label.name = "hitLabel"
-            label.fontSize = 9
-            label.fontColor = .white
-            label.verticalAlignmentMode = .center
-            label.horizontalAlignmentMode = .center
+            label.fontSize = 7
+            label.fontColor = PlatformColor(white: 0.9, alpha: 0.7)
+            label.verticalAlignmentMode = .bottom
+            label.horizontalAlignmentMode = .right
+            label.position = CGPoint(x: size.width / 2 - 2, y: -size.height / 2 + 1)
             label.text = "x\(n)"
             addChild(label)
+            // Plaque neuve — aucune fissure à l'état initial (hitsRemaining == initialHits)
+            addCrackOverlay(hitsRemaining: n, size: size)
         }
 
         if isIndestructible {
@@ -101,6 +116,11 @@ final class BrickNode: SKSpriteNode {
         ])
         let tint = SKAction.colorize(with: .white, colorBlendFactor: blend, duration: 0.10)
         run(.group([wobble, tint]))
+
+        if isArmored {
+            addCrackOverlay(hitsRemaining: remainingHits, size: size)
+            spawnDebris()
+        }
     }
 
     func destroy(completion: @escaping () -> Void) {
@@ -115,6 +135,76 @@ final class BrickNode: SKSpriteNode {
         let remove = SKAction.removeFromParent()
         let done = SKAction.run(completion)
         run(.sequence([firstPhase, secondPhase, done, remove]))
+    }
+}
+
+// MARK: - Armored brick crack overlays
+
+private extension BrickNode {
+
+    // Met à jour les fissures visibles en remplaçant l'overlay existant
+    func addCrackOverlay(hitsRemaining: Int, size: CGSize) {
+        childNode(withName: "crackOverlay")?.removeFromParent()
+        // Plaque neuve : pas de fissures
+        guard hitsRemaining < initialHits else { return }
+        let path = crackPath(hitsRemaining: hitsRemaining, size: size)
+        let node = SKShapeNode(path: path)
+        node.name = "crackOverlay"
+        node.strokeColor = PlatformColor(white: 0.0, alpha: 0.60)
+        node.lineWidth = 1.0
+        node.zPosition = 2
+        addChild(node)
+    }
+
+    // Chemins de fissures pré-définis par tier — cohérents visuellement entre les frames
+    func crackPath(hitsRemaining: Int, size: CGSize) -> CGPath {
+        let path = CGMutablePath()
+        let w = size.width / 2
+        let h = size.height / 2
+        // Ratio de dommage normalisé : 0 = neuf, 1 = dernier coup avant destruction
+        let damage = Double(initialHits - hitsRemaining) / Double(max(initialHits - 1, 1))
+
+        if damage <= 0.5 {
+            // Légèrement endommagé : une fissure diagonale centrale
+            path.move(to: CGPoint(x: -w + 5, y: h - 2))
+            path.addLine(to: CGPoint(x: -1, y: 1))
+            path.addLine(to: CGPoint(x: 3, y: -h + 2))
+        } else {
+            // Gravement endommagé : deux fissures croisées + coins écaillés
+            path.move(to: CGPoint(x: -w + 5, y: h - 2))
+            path.addLine(to: CGPoint(x: -1, y: 1))
+            path.addLine(to: CGPoint(x: 3, y: -h + 2))
+            path.move(to: CGPoint(x: w - 4, y: h - 2))
+            path.addLine(to: CGPoint(x: 2, y: 0))
+            path.addLine(to: CGPoint(x: -4, y: -h + 2))
+            // Coins écaillés
+            path.move(to: CGPoint(x: -w + 2, y: -h + 3))
+            path.addLine(to: CGPoint(x: -w + 5, y: -h + 6))
+            path.move(to: CGPoint(x: w - 2, y: h - 3))
+            path.addLine(to: CGPoint(x: w - 6, y: h - 2))
+        }
+        return path
+    }
+
+    // 3 petits débris argentés qui s'éparpillent à chaque coup sur une brique armored
+    func spawnDebris() {
+        guard let parent = parent else { return }
+        let debrisColor = PlatformColor(white: 0.85, alpha: 1)
+        for idx in 0..<3 {
+            let piece = SKSpriteNode(color: debrisColor, size: CGSize(width: 3, height: 2))
+            piece.position = position
+            piece.zPosition = zPosition + 5
+            parent.addChild(piece)
+            let angle = Double(idx) * (2.0 * .pi / 3.0) + .pi / 4.0
+            let distance: CGFloat = 12
+            let target = CGPoint(
+                x: position.x + CGFloat(cos(angle)) * distance,
+                y: position.y + CGFloat(sin(angle)) * distance
+            )
+            let move = SKAction.move(to: target, duration: 0.18)
+            let fade = SKAction.fadeOut(withDuration: 0.18)
+            piece.run(.sequence([.group([move, fade]), .removeFromParent()]))
+        }
     }
 }
 


### PR DESCRIPTION
Closes #55

## Changes

### `Theme.Color.armored` (Theme.swift)
New silver color constant (`white: 0.72`) used as the base color for all `multiHit` bricks, replacing the row-based color. Makes armored bricks immediately distinguishable from normal bricks at a glance.

### `BrickNode` — crack overlays (BrickNode.swift)

**Visual damage tiers:**
| Hits remaining | Appearance |
|---|---|
| = `initialHits` | Clean silver plate — no cracks |
| `damage ≤ 50%` | One diagonal crack across the body |
| `damage > 50%` | Two crossed cracks + chipped corner marks |

**Implementation details:**
- `addCrackOverlay(hitsRemaining:size:)` removes the previous `SKShapeNode` overlay and draws a new one — called on `init` and on each `applyDamage()`
- `crackPath(hitsRemaining:size:)` returns pre-defined `CGPath` geometry per tier (no random paths — visual consistency between hits)
- `spawnDebris()` spawns 3 small silver `SKSpriteNode` rectangles that fly outward and fade over 0.18 s — called on every `applyDamage()` for armored bricks
- The `"xN"` label is kept as an accessibility fallback but restyled: smaller (7 pt), semi-transparent, bottom-right corner

**No breaking changes** — `BrickCell`, `BrickState`, game logic, and level data are untouched. The `multiHit(Int)` case drives everything.