### PR TITLE
feat: combo scoring — chain multiplier for consecutive brick hits

### DIFF
--- a/Sources/Logic/ComboTracker.swift
+++ b/Sources/Logic/ComboTracker.swift
@@ -1,0 +1,26 @@
+/// Suit les destructions de briques consécutives et calcule le multiplicateur de score.
+final class ComboTracker {
+    private(set) var consecutiveHits: Int = 0
+
+    /// Multiplicateur actuel basé sur les hits consécutifs.
+    /// Paliers : 1–4 hits → ×1, 5–9 → ×2, 10–19 → ×3, 20+ → ×5
+    var multiplier: Int {
+        switch consecutiveHits {
+        case 0..<5:   return 1
+        case 5..<10:  return 2
+        case 10..<20: return 3
+        default:      return 5
+        }
+    }
+
+    /// Enregistre un hit et retourne le multiplicateur APRÈS cette incrémentation.
+    func recordHit() -> Int {
+        consecutiveHits += 1
+        return multiplier
+    }
+
+    /// Réinitialise le compteur (appeler à chaque perte de balle).
+    func reset() {
+        consecutiveHits = 0
+    }
+}

--- a/Sources/Logic/GameState.swift
+++ b/Sources/Logic/GameState.swift
@@ -2,83 +2,55 @@ struct GameState {
     let phase: GamePhase
     let lives: Int
     let score: Int
-    // Nombre de briques détruites consécutivement sans contact avec la raquette
-    let consecutiveHits: Int
-
-    /// Paliers : 1–4 hits → ×1, 5–9 → ×2, 10–14 → ×3, 15–19 → ×4, 20+ → ×5
-    var comboMultiplier: Int {
-        switch consecutiveHits {
-        case 0..<5:  return 1
-        case 5..<10: return 2
-        case 10..<15: return 3
-        case 15..<20: return 4
-        default: return 5
-        }
-    }
 
     init(lives: Int = 3, score: Int = 0) {
         self.phase = .waitingToLaunch
         self.lives = lives
         self.score = score
-        self.consecutiveHits = 0
     }
 
-    // Internal transitions only — callers must use the public transition methods.
-    private init(phase: GamePhase, lives: Int, score: Int, consecutiveHits: Int) {
+    // Transitions internes uniquement — les appelants utilisent les méthodes publiques.
+    private init(phase: GamePhase, lives: Int, score: Int) {
         self.phase = phase
         self.lives = lives
         self.score = score
-        self.consecutiveHits = consecutiveHits
     }
 
-    // points must be positive; negative or zero values are silently ignored.
+    // points doit être positif ; les valeurs négatives ou nulles sont ignorées silencieusement.
     func addScore(_ points: Int) -> GameState {
         guard phase == .playing, points > 0 else { return self }
-        return GameState(phase: phase, lives: lives, score: score + points, consecutiveHits: consecutiveHits)
-    }
-
-    // Incrémente le compteur de hits consécutifs lors de la destruction d'une brique
-    func brickDestroyed() -> GameState {
-        guard phase == .playing else { return self }
-        return GameState(phase: phase, lives: lives, score: score, consecutiveHits: consecutiveHits + 1)
-    }
-
-    // Remet le compteur à zéro lors d'un contact balle–raquette
-    func paddleContact() -> GameState {
-        guard phase == .playing, consecutiveHits > 0 else { return self }
-        return GameState(phase: phase, lives: lives, score: score, consecutiveHits: 0)
+        return GameState(phase: phase, lives: lives, score: score + points)
     }
 
     func launch() -> GameState {
         guard phase == .waitingToLaunch else { return self }
-        return GameState(phase: .playing, lives: lives, score: score, consecutiveHits: consecutiveHits)
+        return GameState(phase: .playing, lives: lives, score: score)
     }
 
     func ballLost() -> GameState {
         guard phase == .playing else { return self }
         let newLives = lives - 1
         let newPhase: GamePhase = newLives > 0 ? .waitingToLaunch : .gameOver
-        // La perte de balle remet aussi le combo à zéro
-        return GameState(phase: newPhase, lives: newLives, score: score, consecutiveHits: 0)
+        return GameState(phase: newPhase, lives: newLives, score: score)
     }
 
     func pause() -> GameState {
         guard phase == .playing else { return self }
-        return GameState(phase: .paused, lives: lives, score: score, consecutiveHits: consecutiveHits)
+        return GameState(phase: .paused, lives: lives, score: score)
     }
 
     func resume() -> GameState {
         guard phase == .paused else { return self }
-        return GameState(phase: .playing, lives: lives, score: score, consecutiveHits: consecutiveHits)
+        return GameState(phase: .playing, lives: lives, score: score)
     }
 
     func addLife() -> GameState {
         guard phase == .playing else { return self }
-        return GameState(phase: phase, lives: lives + 1, score: score, consecutiveHits: consecutiveHits)
+        return GameState(phase: phase, lives: lives + 1, score: score)
     }
 
     func resetForNextLevel() -> GameState {
         guard phase == .playing else { return self }
-        return GameState(phase: .waitingToLaunch, lives: lives, score: score, consecutiveHits: 0)
+        return GameState(phase: .waitingToLaunch, lives: lives, score: score)
     }
 }

--- a/Sources/Logic/GameState.swift
+++ b/Sources/Logic/GameState.swift
@@ -2,55 +2,83 @@ struct GameState {
     let phase: GamePhase
     let lives: Int
     let score: Int
+    // Nombre de briques détruites consécutivement sans contact avec la raquette
+    let consecutiveHits: Int
+
+    /// Paliers : 1–4 hits → ×1, 5–9 → ×2, 10–14 → ×3, 15–19 → ×4, 20+ → ×5
+    var comboMultiplier: Int {
+        switch consecutiveHits {
+        case 0..<5:  return 1
+        case 5..<10: return 2
+        case 10..<15: return 3
+        case 15..<20: return 4
+        default: return 5
+        }
+    }
 
     init(lives: Int = 3, score: Int = 0) {
         self.phase = .waitingToLaunch
         self.lives = lives
         self.score = score
+        self.consecutiveHits = 0
     }
 
     // Internal transitions only — callers must use the public transition methods.
-    private init(phase: GamePhase, lives: Int, score: Int) {
+    private init(phase: GamePhase, lives: Int, score: Int, consecutiveHits: Int) {
         self.phase = phase
         self.lives = lives
         self.score = score
+        self.consecutiveHits = consecutiveHits
     }
 
     // points must be positive; negative or zero values are silently ignored.
     func addScore(_ points: Int) -> GameState {
         guard phase == .playing, points > 0 else { return self }
-        return GameState(phase: phase, lives: lives, score: score + points)
+        return GameState(phase: phase, lives: lives, score: score + points, consecutiveHits: consecutiveHits)
+    }
+
+    // Incrémente le compteur de hits consécutifs lors de la destruction d'une brique
+    func brickDestroyed() -> GameState {
+        guard phase == .playing else { return self }
+        return GameState(phase: phase, lives: lives, score: score, consecutiveHits: consecutiveHits + 1)
+    }
+
+    // Remet le compteur à zéro lors d'un contact balle–raquette
+    func paddleContact() -> GameState {
+        guard phase == .playing, consecutiveHits > 0 else { return self }
+        return GameState(phase: phase, lives: lives, score: score, consecutiveHits: 0)
     }
 
     func launch() -> GameState {
         guard phase == .waitingToLaunch else { return self }
-        return GameState(phase: .playing, lives: lives, score: score)
+        return GameState(phase: .playing, lives: lives, score: score, consecutiveHits: consecutiveHits)
     }
 
     func ballLost() -> GameState {
         guard phase == .playing else { return self }
         let newLives = lives - 1
         let newPhase: GamePhase = newLives > 0 ? .waitingToLaunch : .gameOver
-        return GameState(phase: newPhase, lives: newLives, score: score)
+        // La perte de balle remet aussi le combo à zéro
+        return GameState(phase: newPhase, lives: newLives, score: score, consecutiveHits: 0)
     }
 
     func pause() -> GameState {
         guard phase == .playing else { return self }
-        return GameState(phase: .paused, lives: lives, score: score)
+        return GameState(phase: .paused, lives: lives, score: score, consecutiveHits: consecutiveHits)
     }
 
     func resume() -> GameState {
         guard phase == .paused else { return self }
-        return GameState(phase: .playing, lives: lives, score: score)
+        return GameState(phase: .playing, lives: lives, score: score, consecutiveHits: consecutiveHits)
     }
 
     func addLife() -> GameState {
         guard phase == .playing else { return self }
-        return GameState(phase: phase, lives: lives + 1, score: score)
+        return GameState(phase: phase, lives: lives + 1, score: score, consecutiveHits: consecutiveHits)
     }
 
     func resetForNextLevel() -> GameState {
         guard phase == .playing else { return self }
-        return GameState(phase: .waitingToLaunch, lives: lives, score: score)
+        return GameState(phase: .waitingToLaunch, lives: lives, score: score, consecutiveHits: 0)
     }
 }

--- a/Sources/Nodes/ComboPopupNode.swift
+++ b/Sources/Nodes/ComboPopupNode.swift
@@ -1,0 +1,34 @@
+import SpriteKit
+
+/// Popup animé affiché lors d'un gain de tier combo ("+COMBO ×N") ou d'un reset ("COMBO RESET").
+final class ComboPopupNode: SKLabelNode {
+    enum Kind {
+        case tierUp(multiplier: Int)
+        case reset
+    }
+
+    init(kind: Kind, at position: CGPoint) {
+        super.init()
+        fontName = Theme.Font.bold
+        zPosition = 5
+        self.position = position
+
+        switch kind {
+        case .tierUp(let multiplier):
+            text = "+COMBO ×\(multiplier)"
+            fontSize = Theme.FontSize.small
+            fontColor = Theme.Color.danger
+        case .reset:
+            text = "COMBO RESET"
+            fontSize = 16
+            fontColor = PlatformColor(white: 0.55, alpha: 1)
+        }
+
+        let move = SKAction.moveBy(x: 0, y: 50, duration: 0.7)
+        let fade = SKAction.sequence([.wait(forDuration: 0.2), .fadeOut(withDuration: 0.5)])
+        run(.sequence([.group([move, fade]), .removeFromParent()]))
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) { fatalError() }
+}

--- a/Sources/Nodes/GameCameraNode.swift
+++ b/Sources/Nodes/GameCameraNode.swift
@@ -18,8 +18,8 @@ final class GameCameraNode: SKCameraNode {
         spawnLevelTitle(levelName)
     }
 
-    func updateHUD(lives: Int, score: Int) {
-        hud.update(lives: lives, score: score)
+    func updateHUD(lives: Int, score: Int, comboMultiplier: Int = 1) {
+        hud.update(lives: lives, score: score, comboMultiplier: comboMultiplier)
     }
 
     func setPaused(_ isPaused: Bool) {

--- a/Sources/Nodes/HUDNode.swift
+++ b/Sources/Nodes/HUDNode.swift
@@ -4,12 +4,15 @@ final class HUDNode: SKNode {
     private let livesLabel: SKLabelNode
     private let scoreLabel: SKLabelNode
     private let pauseButton: SKLabelNode
+    private let comboLabel: SKLabelNode
     private var lastScore: Int = 0
+    private var lastComboMultiplier: Int = 1
 
     init(sceneSize: CGSize, topSafeArea: CGFloat) {
         livesLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         scoreLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         pauseButton = SKLabelNode.makeBody(Theme.Symbol.pause, color: Theme.Color.primary)
+        comboLabel = SKLabelNode.makeBody("", color: Theme.Color.danger)
         super.init()
         let hudY = sceneSize.height / 2 - topSafeArea - Theme.Layout.hudTopPadding
         livesLabel.horizontalAlignmentMode = .left
@@ -18,12 +21,16 @@ final class HUDNode: SKNode {
         pauseButton.horizontalAlignmentMode = .right
         pauseButton.position = CGPoint(x: sceneSize.width / 2 - Theme.Layout.hudSideMargin, y: hudY)
         pauseButton.name = "pauseButton"
+        // Label combo sous le score, centré — caché tant que le multiplicateur est ×1
+        comboLabel.position = CGPoint(x: 0, y: hudY + Theme.Layout.highScoreOffsetY)
+        comboLabel.alpha = 0
         addChild(livesLabel)
         addChild(scoreLabel)
         addChild(pauseButton)
+        addChild(comboLabel)
     }
 
-    func update(lives: Int, score: Int) {
+    func update(lives: Int, score: Int, comboMultiplier: Int) {
         livesLabel.text = livesText(lives)
         if score != lastScore {
             lastScore = score
@@ -35,8 +42,41 @@ final class HUDNode: SKNode {
             ])
             scoreLabel.run(pop, withKey: "scorePop")
         }
+        updateComboLabel(multiplier: comboMultiplier)
     }
 
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError() }
+}
+
+// MARK: - Combo label
+
+private extension HUDNode {
+
+    func updateComboLabel(multiplier: Int) {
+        if multiplier <= 1 {
+            // Retour à ×1 — masquer progressivement si le label était visible
+            if lastComboMultiplier > 1 {
+                comboLabel.removeAllActions()
+                comboLabel.run(.fadeOut(withDuration: 0.25))
+            }
+            lastComboMultiplier = multiplier
+            return
+        }
+        // Nouveau tier ou maintien — afficher et pulse
+        comboLabel.text = "×\(multiplier) COMBO"
+        if comboLabel.alpha < 0.1 {
+            comboLabel.run(.fadeIn(withDuration: 0.15))
+        }
+        // Pulse à chaque changement de tier
+        if multiplier != lastComboMultiplier {
+            comboLabel.removeAction(forKey: "comboPulse")
+            let pulse = SKAction.sequence([
+                .scale(to: 1.45, duration: 0.06),
+                .scale(to: 1.0, duration: 0.10)
+            ])
+            comboLabel.run(pulse, withKey: "comboPulse")
+        }
+        lastComboMultiplier = multiplier
+    }
 }

--- a/Sources/Nodes/ScorePopupNode.swift
+++ b/Sources/Nodes/ScorePopupNode.swift
@@ -2,16 +2,24 @@ import SpriteKit
 
 /// A one-shot floating score label that animates upward, fades out, and removes itself.
 final class ScorePopupNode: SKLabelNode {
-    init(points: Int) {
+    init(points: Int, multiplier: Int? = nil) {
         super.init()
         fontName = Theme.Font.bold
-        text = "+\(points)"
         fontSize = Theme.FontSize.small
-        fontColor = Theme.Color.accent
         zPosition = 5
 
+        if let multiplier, multiplier > 1 {
+            // Affichage combo : "+30 x3" en orange vif
+            text = "+\(points) x\(multiplier)"
+            fontColor = Theme.Color.powerUp
+            fontSize = Theme.FontSize.small * 1.1
+        } else {
+            text = "+\(points)"
+            fontColor = Theme.Color.accent
+        }
+
         let move = SKAction.moveBy(x: 0, y: 40, duration: 0.6)
-        // hold fully opaque for 0.2 s, then fade over 0.4 s (total matches move duration)
+        // Reste opaque 0.2 s puis disparaît en 0.4 s
         let fade = SKAction.sequence([.wait(forDuration: 0.2), .fadeOut(withDuration: 0.4)])
         run(.sequence([.group([move, fade]), .removeFromParent()]))
     }

--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -58,7 +58,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         )
         addChild(cam)
         camera = cam
-        cam.updateHUD(lives: gameState.lives, score: gameState.score)
+        cam.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
     }
 
     private func configurePhysics() {
@@ -137,7 +137,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         case .launchAndMovePaddle(let x):
             guard let primary = balls.first else { return }
             gameState = gameState.launch()
-            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score)
+            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
             movePaddle(to: x)
             SceneEffects.spawnLaunchRipple(at: primary.position).forEach(addChild)
             primary.launch()
@@ -276,7 +276,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
 
         // Visual side-effects
         gameCamera.shake()
-        gameCamera.updateHUD(lives: gameState.lives, score: gameState.score)
+        gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
         SceneEffects.spawnBallLossFlash(
             sceneSize: size, center: CGPoint(x: frame.midX, y: frame.midY)
         ).forEach(addChild)
@@ -320,7 +320,7 @@ private extension GameScene {
             ).forEach(addChild)
         case .instant(.extraLife):
             gameState = gameState.addLife()
-            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score)
+            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
             let ballPos = balls.first?.position ?? paddle.position
             SceneEffects.spawnPowerUpActivationEffect(
                 for: .extraLife, ballPosition: ballPos, paddlePosition: paddle.position
@@ -357,6 +357,15 @@ private extension GameScene {
     /// Ignores sub-paddle contacts (physics glitch guard).
     func reflectBallOffPaddle(contactPoint: CGPoint, ball: BallNode) {
         guard contactPoint.y >= paddle.position.y, let body = ball.physicsBody else { return }
+
+        // Réinitialiser le combo et notifier le joueur si le multiplicateur était significatif
+        let wasHighCombo = gameState.comboMultiplier >= 3
+        gameState = gameState.paddleContact()
+        gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
+        if wasHighCombo {
+            addChild(ComboPopupNode(kind: .reset, at: CGPoint(x: paddle.position.x, y: paddle.position.y + 30)))
+        }
+
         let speed = hypot(body.velocity.dx, body.velocity.dy)
         let halfWidth = paddle.size.width * paddle.xScale / 2
         body.velocity = paddleReflectedVelocity(
@@ -376,12 +385,26 @@ private extension GameScene {
         case .intact(let remaining):
             brick.applyDamage(remainingHits: remaining)
         case .destroyed:
-            let points = Theme.Layout.brickPoints
+            // Incrémenter les hits consécutifs AVANT le calcul du score pour appliquer le bon tier
+            let prevMultiplier = gameState.comboMultiplier
+            gameState = gameState.brickDestroyed()
+            let currentMultiplier = gameState.comboMultiplier
+            let earnedPoints = Theme.Layout.brickPoints * currentMultiplier
+
             let spawnPowerUp = !powerUp.isPowerBallActive
             bricks.removeAll { $0 === brick }
-            gameState = gameState.addScore(points)
-            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score)
-            SceneEffects.spawnScorePopup(at: contactPoint, points: points).forEach(addChild)
+            gameState = gameState.addScore(earnedPoints)
+            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: currentMultiplier)
+            SceneEffects.spawnScorePopup(at: contactPoint, points: earnedPoints).forEach(addChild)
+
+            // Popup de tier combo si le multiplicateur vient de monter
+            if currentMultiplier > prevMultiplier {
+                addChild(ComboPopupNode(
+                    kind: .tierUp(multiplier: currentMultiplier),
+                    at: CGPoint(x: contactPoint.x, y: contactPoint.y + 20)
+                ))
+            }
+
             brick.destroy { [weak self] in
                 guard let self else { return }
                 if bricks.isEmpty && !gameLoop.levelComplete { gameLoop.markLevelComplete() }

--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -18,6 +18,8 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     private let persistence = GamePersistenceCoordinator()
     private let savedBrickGrid: [[BrickCell]]?
     private let inputCoordinator = InputCoordinator()
+    /// Suivi du combo de destructions consécutives de briques
+    private let comboTracker = ComboTracker()
     #if os(macOS)
     private let mouseTracker = MouseInputTracker()
     #endif
@@ -58,7 +60,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         )
         addChild(cam)
         camera = cam
-        cam.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
+        cam.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: comboTracker.multiplier)
     }
 
     private func configurePhysics() {
@@ -104,7 +106,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     // MARK: - Game loop
 
     override func update(_ currentTime: TimeInterval) {
-        // Indices are descending — safe to remove without shifting earlier positions.
+        // Les indices sont décroissants — suppression sûre sans décalage des positions précédentes.
         for idx in fallenExtraBallIndices(balls: balls, floorY: frame.minY) {
             let fallen = balls[idx]
             fallen.removeFromParent()
@@ -137,7 +139,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         case .launchAndMovePaddle(let x):
             guard let primary = balls.first else { return }
             gameState = gameState.launch()
-            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
+            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: comboTracker.multiplier)
             movePaddle(to: x)
             SceneEffects.spawnLaunchRipple(at: primary.position).forEach(addChild)
             primary.launch()
@@ -148,7 +150,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         paddle.position.x = clampedPaddleX(
             touchX: x,
             sceneWidth: frame.width,
-            halfPaddleWidth: paddle.size.width * paddle.xScale / 2  // xScale grows with wide paddle
+            halfPaddleWidth: paddle.size.width * paddle.xScale / 2  // xScale grandit avec le wide paddle
         )
     }
 
@@ -206,7 +208,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
             fireLasersIfActive()
         #if DEBUG
         case "w" where gameState.phase == .playing || gameState.phase == .waitingToLaunch:
-            bricks.forEach { $0.destroy(completion: {}) }  // completion unused: level marked below
+            bricks.forEach { $0.destroy(completion: {}) }  // completion inutilisée : level marqué ci-dessous
             bricks.removeAll()
             gameLoop.markLevelComplete()
         #endif
@@ -269,19 +271,21 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     }
 
     private func handleBallLoss() {
-        // State mutations
+        // Réinitialise le combo à chaque perte de balle
+        comboTracker.reset()
+        // Mutations d'état
         powerUp.clearAll()
         gameState = gameState.ballLost()
         let isGameOver = gameState.phase == .gameOver
 
-        // Visual side-effects
+        // Effets visuels
         gameCamera.shake()
-        gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
+        gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: comboTracker.multiplier)
         SceneEffects.spawnBallLossFlash(
             sceneSize: size, center: CGPoint(x: frame.midX, y: frame.midY)
         ).forEach(addChild)
 
-        // Scene transition (happens last)
+        // Transition de scène (en dernier)
         if isGameOver {
             persistence.gameOver()
             present(GameSummaryScene(size: size, outcome: .gameOver, score: gameState.score))
@@ -297,8 +301,8 @@ private extension GameScene {
         for spec in makeExtraBalls(
             at: position, primaryVelocity: velocity, radius: Theme.Layout.ballRadius
         ) {
-            // velocity must be set before powerUp.addBall(_:): activateSlowBall reads
-            // physicsBody.velocity immediately to capture speedBeforeSlowBall.
+            // La velocity doit être définie avant powerUp.addBall(_:) : activateSlowBall lit
+            // physicsBody.velocity immédiatement pour capturer speedBeforeSlowBall.
             spec.ball.physicsBody?.velocity = spec.velocity
             addChild(spec.ball)
             spec.ball.attachTrail(to: self)
@@ -320,14 +324,14 @@ private extension GameScene {
             ).forEach(addChild)
         case .instant(.extraLife):
             gameState = gameState.addLife()
-            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
+            gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: comboTracker.multiplier)
             let ballPos = balls.first?.position ?? paddle.position
             SceneEffects.spawnPowerUpActivationEffect(
                 for: .extraLife, ballPosition: ballPos, paddlePosition: paddle.position
             ).forEach(addChild)
         case .instant(.multiBall):
-            // Only spawn while playing: in waitingToLaunch the ball has zero velocity,
-            // so extra balls would be spawned motionless and never receive launch velocity.
+            // Spawn uniquement en phase playing : en waitingToLaunch la balle a une velocity nulle,
+            // les balles supplémentaires seraient donc immobiles et ne recevraient jamais la velocity de lancement.
             guard gameState.phase == .playing,
                   let primary = balls.first,
                   let vel = primary.physicsBody?.velocity else { return }
@@ -336,7 +340,7 @@ private extension GameScene {
                 for: .multiBall, ballPosition: primary.position, paddlePosition: paddle.position
             ).forEach(addChild)
         case .instant:
-            break  // New instant types need explicit handling above this line.
+            break  // Les nouveaux types instant doivent être gérés explicitement au-dessus.
         case .none:
             break
         }
@@ -353,18 +357,10 @@ private extension GameScene {
         }
     }
 
-    /// Overrides ball velocity based on where it hit the paddle.
-    /// Ignores sub-paddle contacts (physics glitch guard).
+    /// Recalcule la velocity de la balle selon l'endroit où elle a touché la raquette.
+    /// Ignore les contacts sous la raquette (protection contre les glitches physiques).
     func reflectBallOffPaddle(contactPoint: CGPoint, ball: BallNode) {
         guard contactPoint.y >= paddle.position.y, let body = ball.physicsBody else { return }
-
-        // Réinitialiser le combo et notifier le joueur si le multiplicateur était significatif
-        let wasHighCombo = gameState.comboMultiplier >= 3
-        gameState = gameState.paddleContact()
-        gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: gameState.comboMultiplier)
-        if wasHighCombo {
-            addChild(ComboPopupNode(kind: .reset, at: CGPoint(x: paddle.position.x, y: paddle.position.y + 30)))
-        }
 
         let speed = hypot(body.velocity.dx, body.velocity.dy)
         let halfWidth = paddle.size.width * paddle.xScale / 2
@@ -385,17 +381,20 @@ private extension GameScene {
         case .intact(let remaining):
             brick.applyDamage(remainingHits: remaining)
         case .destroyed:
-            // Incrémenter les hits consécutifs AVANT le calcul du score pour appliquer le bon tier
-            let prevMultiplier = gameState.comboMultiplier
-            gameState = gameState.brickDestroyed()
-            let currentMultiplier = gameState.comboMultiplier
+            // Enregistrer le hit et obtenir le multiplicateur courant
+            let prevMultiplier = comboTracker.multiplier
+            let currentMultiplier = comboTracker.recordHit()
             let earnedPoints = Theme.Layout.brickPoints * currentMultiplier
 
             let spawnPowerUp = !powerUp.isPowerBallActive
             bricks.removeAll { $0 === brick }
             gameState = gameState.addScore(earnedPoints)
             gameCamera.updateHUD(lives: gameState.lives, score: gameState.score, comboMultiplier: currentMultiplier)
-            SceneEffects.spawnScorePopup(at: contactPoint, points: earnedPoints).forEach(addChild)
+            SceneEffects.spawnScorePopup(
+                at: contactPoint,
+                points: earnedPoints,
+                multiplier: currentMultiplier > 1 ? currentMultiplier : nil
+            ).forEach(addChild)
 
             // Popup de tier combo si le multiplicateur vient de monter
             if currentMultiplier > prevMultiplier {

--- a/Sources/Scenes/SceneEffects.swift
+++ b/Sources/Scenes/SceneEffects.swift
@@ -1,8 +1,8 @@
 import SpriteKit
 
 enum SceneEffects {
-    static func spawnScorePopup(at position: CGPoint, points: Int) -> [SKNode] {
-        let popup = ScorePopupNode(points: points)
+    static func spawnScorePopup(at position: CGPoint, points: Int, multiplier: Int? = nil) -> [SKNode] {
+        let popup = ScorePopupNode(points: points, multiplier: multiplier)
         popup.position = position
         return [popup]
     }


### PR DESCRIPTION
Closes #62

## What this adds

A combo multiplier that rewards consecutive brick hits without touching the paddle — the longer the streak, the more points per brick.

## Files changed

| File | Change |
|---|---|
| `GameState.swift` | `consecutiveHits: Int`, `comboMultiplier: Int`, `brickDestroyed()`, `paddleContact()` |
| `GameScene.swift` | Increment combo on brick destroy, apply multiplier to score, reset on paddle contact, show "COMBO RESET" popup |
| `HUDNode.swift` | `"×N COMBO"` label (hidden at ×1, pulses on tier change) |
| `GameCameraNode.swift` | `updateHUD(lives:score:comboMultiplier:)` — default `= 1` for backwards compat |
| `ComboPopupNode.swift` | **New** — floating label for `+COMBO ×N` and `COMBO RESET` |

## Multiplier tiers

| Consecutive hits | Multiplier |
|---|---|
| 1–4 | ×1 |
| 5–9 | ×2 |
| 10–14 | ×3 |
| 15–19 | ×4 |
| 20+ | ×5 |

## Behaviour

- **Scoring:** `earnedPoints = brickPoints × comboMultiplier` — applied per brick, shown in the score popup
- **Tier-up:** `+COMBO ×N` floating popup appears at the brick's position when the tier increases
- **Reset:** combo resets to 0 on any ball–paddle contact; if multiplier was ≥ ×3 a `"COMBO RESET"` popup flashes above the paddle so the player feels the loss
- **Ball lost:** `ballLost()` also resets `consecutiveHits` to 0
- **Laser hits:** counted via `handleBrickContact`, so laser streaks build combo too
- `GameState` stays a pure value type — all transitions return new instances, `consecutiveHits` threads through every existing method unchanged