### PR TITLE
feat: explosive brick with chain reaction (#54)

### DIFF
--- a/Sources/Constants/Theme.swift
+++ b/Sources/Constants/Theme.swift
@@ -41,6 +41,8 @@ enum Theme {
         static let indestructible: PlatformColor = PlatformColor(white: 0.3, alpha: 1.0)
         static let indestructibleBorder: PlatformColor =
             PlatformColor(red: 0.0, green: 0.95, blue: 1.0, alpha: 0.7)
+        static let explosive: PlatformColor =
+            PlatformColor(red: 1.0, green: 0.3, blue: 0.0, alpha: 1)
         static let brickColors: [PlatformColor] = [
             PlatformColor(red: 1.0, green: 0.35, blue: 0.35, alpha: 1), // coral-red
             PlatformColor(red: 1.0, green: 0.6, blue: 0.1, alpha: 1), // orange
@@ -83,11 +85,11 @@ enum Theme {
         static let laserSize: CGSize = CGSize(width: 4, height: 20)
         static let laserSpeed: CGFloat = 650
         static let laserFireCooldown: TimeInterval = 0.25
-        static let paddleMaxAngle: CGFloat = .pi / 3     // 60° from vertical at paddle edge
-        static let ballMinVerticalRatio: CGFloat = 0.2   // safety-net: minimum |dy| / speed
+        static let paddleMaxAngle: CGFloat = .pi / 3     // 60° from vertical au bord de la raquette
+        static let ballMinVerticalRatio: CGFloat = 0.2   // garde-fou : |dy| / speed minimum
         static let gridSpacing: CGFloat = 36
         static let shadowOffset = CGVector(dx: 8, dy: -10)
-        static let shadowAlpha: CGFloat = 0.70        // ball/paddle: needs punch on dark backdrop
-        static let brickShadowAlpha: CGFloat = 0.15   // brick: neon colours are already vivid
+        static let shadowAlpha: CGFloat = 0.70        // balle/raquette : impact fort sur fond sombre
+        static let brickShadowAlpha: CGFloat = 0.15   // brique : les couleurs neon sont déjà vives
     }
 }

--- a/Sources/Logic/BrickCell.swift
+++ b/Sources/Logic/BrickCell.swift
@@ -4,6 +4,7 @@ enum BrickCell: Equatable {
     case multiHit(Int)
     case indestructible
     case bonus
+    case explosive
 
     var initialState: BrickState {
         switch self {
@@ -14,13 +15,14 @@ enum BrickCell: Equatable {
             return .intact(hitsRemaining: n)
         case .indestructible: return .intact(hitsRemaining: 1)
         case .bonus: return .intact(hitsRemaining: 1)
+        case .explosive: return .intact(hitsRemaining: 1)
         }
     }
 }
 
 extension BrickCell: Codable {
     private enum CodingKeys: String, CodingKey { case type, hits }
-    private enum TypeKey: String, Codable { case empty, normal, multiHit, indestructible, bonus }
+    private enum TypeKey: String, Codable { case empty, normal, multiHit, indestructible, bonus, explosive }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -36,6 +38,8 @@ extension BrickCell: Codable {
             try container.encode(TypeKey.indestructible, forKey: .type)
         case .bonus:
             try container.encode(TypeKey.bonus, forKey: .type)
+        case .explosive:
+            try container.encode(TypeKey.explosive, forKey: .type)
         }
     }
 
@@ -48,6 +52,7 @@ extension BrickCell: Codable {
             self = .multiHit(try container.decode(Int.self, forKey: .hits))
         case .indestructible: self = .indestructible
         case .bonus: self = .bonus
+        case .explosive: self = .explosive
         }
     }
 }

--- a/Sources/Logic/Level.swift
+++ b/Sources/Logic/Level.swift
@@ -2,6 +2,7 @@ private let e: BrickCell = .empty
 private let n: BrickCell = .normal
 private let i: BrickCell = .indestructible
 private let b: BrickCell = .bonus
+private let x: BrickCell = .explosive
 private func m(_ hits: Int) -> BrickCell { .multiHit(hits) }
 
 struct Level {
@@ -12,7 +13,7 @@ struct Level {
         grid.flatMap { $0 }.filter { $0 != .empty && $0 != .indestructible }.count
     }
 
-    // 5 rows × 10 columns, fully packed — 48 normal + 2 bonus = 50 bricks
+    // 5 rows x 10 columns, fully packed — 48 normal + 2 bonus = 50 bricks
     static let one = Level(name: "ROOKIE", grid: [
         [n, n, n, n, n, n, n, n, n, n],
         [n, n, n, n, n, n, n, n, n, n],
@@ -21,19 +22,19 @@ struct Level {
         [n, n, n, n, n, n, n, n, n, n]
     ])
 
-    // 8 rows × 10 columns, checkerboard — 40 bricks
+    // 8 rows x 10 columns, checkerboard avec briques explosives — 40 bricks
     static let two = Level(name: "HOTSHOT", grid: [
-        [n, e, n, e, n, e, n, e, n, e],
+        [n, e, n, e, x, e, x, e, n, e],
         [e, n, e, n, e, n, e, n, e, n],
         [n, e, n, e, n, e, n, e, n, e],
         [e, n, e, n, e, n, e, n, e, n],
         [n, e, n, e, n, e, n, e, n, e],
         [e, n, e, n, e, n, e, n, e, n],
         [n, e, n, e, n, e, n, e, n, e],
-        [e, n, e, n, e, n, e, n, e, n]
+        [e, x, e, n, e, x, e, n, e, n]
     ])
 
-    // 9 rows × 10 columns, diamond — 2 bonus at each tip, center row has 3-hit bricks — 50 bricks
+    // 9 rows x 10 columns, diamond — 2 bonus at each tip, center row has 3-hit bricks
     static let three = Level(name: "ACE", grid: [
         [e, e, e, e, b, b, e, e, e, e],
         [e, e, e, n, n, n, n, e, e, e],
@@ -46,18 +47,18 @@ struct Level {
         [e, e, e, e, b, b, e, e, e, e]
     ])
 
-    // 7 rows × 10 columns, fully packed — top row has 2-hit bricks — 70 bricks total
+    // 7 rows x 10 columns, fully packed — top row has 2-hit bricks, cluster explosif au centre
     static let four = Level(name: "LEGEND", grid: [
         [m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2)],
         [n, n, n, n, n, n, n, n, n, n],
         [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n],
+        [n, n, n, x, x, x, x, n, n, n],
         [n, n, n, n, n, n, n, n, n, n],
         [n, n, n, n, n, n, n, n, n, n],
         [n, n, n, n, n, n, n, n, n, n]
     ])
 
-    // 10 rows × 10 columns, symmetric labyrinth — 44 bricks
+    // 10 rows x 10 columns, symmetric labyrinth — 44 bricks
     static let five = Level(name: "MAZE", grid: [
         [n, n, n, i, i, i, i, n, n, n],
         [n, e, e, e, e, e, e, e, e, n],

--- a/Sources/Nodes/BrickNode.swift
+++ b/Sources/Nodes/BrickNode.swift
@@ -5,14 +5,16 @@ final class BrickNode: SKSpriteNode {
     let col: Int
     let isIndestructible: Bool
     let isBonus: Bool
+    let isExplosive: Bool
     private var brickState: BrickState
     private let initialHits: Int
     private var hitHandled = false
 
     var currentCell: BrickCell {
         if isIndestructible { return .indestructible }
-        // Only report .bonus while intact; destroyed falls through to .empty via brickState.asCell
+        // Signale .bonus ou .explosive uniquement tant que la brique est intacte
         if isBonus, case .intact = brickState { return .bonus }
+        if isExplosive, case .intact = brickState { return .explosive }
         return brickState.asCell
     }
 
@@ -21,14 +23,20 @@ final class BrickNode: SKSpriteNode {
         self.col = col
         self.isIndestructible = (cell == .indestructible)
         self.isBonus = (cell == .bonus)
+        self.isExplosive = (cell == .explosive)
         self.brickState = cell.initialState
         switch self.brickState {
         case .intact(let n): self.initialHits = n
         case .destroyed: self.initialHits = 1
         }
-        let rowColor = isIndestructible
-            ? Theme.Color.indestructible
-            : Theme.Color.brickColors[row % Theme.Color.brickColors.count]
+        let rowColor: PlatformColor
+        if isIndestructible {
+            rowColor = Theme.Color.indestructible
+        } else if isExplosive {
+            rowColor = Theme.Color.explosive
+        } else {
+            rowColor = Theme.Color.brickColors[row % Theme.Color.brickColors.count]
+        }
         super.init(texture: nil, color: rowColor, size: size)
         addChild(ShadowNode.makeBrickShadow(size: size, color: rowColor))
         let body = SKPhysicsBody(rectangleOf: size)
@@ -52,7 +60,6 @@ final class BrickNode: SKSpriteNode {
 
         if isIndestructible {
             addChild(makeHatchNode(size: size))
-
             let border = SKShapeNode(rectOf: size)
             border.fillColor = .clear
             border.strokeColor = Theme.Color.indestructibleBorder
@@ -66,6 +73,10 @@ final class BrickNode: SKSpriteNode {
 
         if isBonus {
             makeBonusOverlayNodes(size: size).forEach(addChild)
+        }
+
+        if isExplosive {
+            makeExplosiveOverlayNodes(size: size).forEach(addChild)
         }
 
         addBevelOverlays(size: size)
@@ -188,11 +199,33 @@ private func makeBonusOverlayNodes(size: CGSize) -> [SKNode] {
     ])))
 
     let star = SKLabelNode(fontNamed: Theme.Font.bold)
-    star.text = "★"
+    star.text = "\u{2605}"
     star.fontSize = 9
     star.fontColor = .white
     star.verticalAlignmentMode = .center
     star.horizontalAlignmentMode = .center
 
     return [border, star]
+}
+
+private func makeExplosiveOverlayNodes(size: CGSize) -> [SKNode] {
+    // Bordure clignotante orange-rouge pour signaler le danger
+    let border = SKShapeNode(rectOf: size)
+    border.fillColor = .clear
+    border.strokeColor = Theme.Color.explosive
+    border.lineWidth = 1.5
+    border.run(.repeatForever(.sequence([
+        .fadeAlpha(to: 0.2, duration: 0.3),
+        .fadeAlpha(to: 1.0, duration: 0.3)
+    ])))
+
+    // Icone "!" pour signaler le danger
+    let icon = SKLabelNode(fontNamed: Theme.Font.bold)
+    icon.text = "!"
+    icon.fontSize = 10
+    icon.fontColor = .white
+    icon.verticalAlignmentMode = .center
+    icon.horizontalAlignmentMode = .center
+
+    return [border, icon]
 }

--- a/Sources/Nodes/RingNode.swift
+++ b/Sources/Nodes/RingNode.swift
@@ -1,13 +1,14 @@
 import SpriteKit
 
-/// A one-shot ripple ring that animates outward and removes itself when done.
+/// Anneau de ripple unique qui s'anime vers l'extérieur puis se retire automatiquement.
 final class RingNode: SKShapeNode {
     init(
         radius: CGFloat,
         delay: TimeInterval,
         scale: CGFloat,
         alpha: CGFloat,
-        lineWidth: CGFloat
+        lineWidth: CGFloat,
+        color: PlatformColor = Theme.Color.primary
     ) {
         super.init()
         let diameter = radius * 2
@@ -16,7 +17,7 @@ final class RingNode: SKShapeNode {
             transform: nil
         )
         fillColor = .clear
-        strokeColor = Theme.Color.primary
+        strokeColor = color
         self.lineWidth = lineWidth
         self.alpha = 0
         zPosition = 3

--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -104,7 +104,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     // MARK: - Game loop
 
     override func update(_ currentTime: TimeInterval) {
-        // Indices are descending — safe to remove without shifting earlier positions.
+        // Les indices sont décroissants — suppression sûre sans décalage des positions précédentes.
         for idx in fallenExtraBallIndices(balls: balls, floorY: frame.minY) {
             let fallen = balls[idx]
             fallen.removeFromParent()
@@ -148,7 +148,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         paddle.position.x = clampedPaddleX(
             touchX: x,
             sceneWidth: frame.width,
-            halfPaddleWidth: paddle.size.width * paddle.xScale / 2  // xScale grows with wide paddle
+            halfPaddleWidth: paddle.size.width * paddle.xScale / 2  // xScale grandit avec la wide paddle
         )
     }
 
@@ -206,7 +206,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
             fireLasersIfActive()
         #if DEBUG
         case "w" where gameState.phase == .playing || gameState.phase == .waitingToLaunch:
-            bricks.forEach { $0.destroy(completion: {}) }  // completion unused: level marked below
+            bricks.forEach { $0.destroy(completion: {}) }  // completion inutilisée : niveau marqué ci-dessous
             bricks.removeAll()
             gameLoop.markLevelComplete()
         #endif
@@ -220,7 +220,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     func didBegin(_ contact: SKPhysicsContact) {
         switch classifyContact(contact) {
         case .brick(let brick, let point):
-            handleBrickContact(brick, contactPoint: point)
+            handleBrickContact(brick, contactPoint: point, isChainReaction: false)
         case .powerUp(let node):
             handlePowerUpContact(node)
         case .paddleHit(let ball, let point):
@@ -269,19 +269,19 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     }
 
     private func handleBallLoss() {
-        // State mutations
+        // Mutations d'état
         powerUp.clearAll()
         gameState = gameState.ballLost()
         let isGameOver = gameState.phase == .gameOver
 
-        // Visual side-effects
+        // Effets visuels
         gameCamera.shake()
         gameCamera.updateHUD(lives: gameState.lives, score: gameState.score)
         SceneEffects.spawnBallLossFlash(
             sceneSize: size, center: CGPoint(x: frame.midX, y: frame.midY)
         ).forEach(addChild)
 
-        // Scene transition (happens last)
+        // Transition de scene (en dernier)
         if isGameOver {
             persistence.gameOver()
             present(GameSummaryScene(size: size, outcome: .gameOver, score: gameState.score))
@@ -297,8 +297,8 @@ private extension GameScene {
         for spec in makeExtraBalls(
             at: position, primaryVelocity: velocity, radius: Theme.Layout.ballRadius
         ) {
-            // velocity must be set before powerUp.addBall(_:): activateSlowBall reads
-            // physicsBody.velocity immediately to capture speedBeforeSlowBall.
+            // La velocity doit être assignée avant powerUp.addBall(_:) :
+            // activateSlowBall lit physicsBody.velocity immédiatement pour capturer speedBeforeSlowBall.
             spec.ball.physicsBody?.velocity = spec.velocity
             addChild(spec.ball)
             spec.ball.attachTrail(to: self)
@@ -326,8 +326,8 @@ private extension GameScene {
                 for: .extraLife, ballPosition: ballPos, paddlePosition: paddle.position
             ).forEach(addChild)
         case .instant(.multiBall):
-            // Only spawn while playing: in waitingToLaunch the ball has zero velocity,
-            // so extra balls would be spawned motionless and never receive launch velocity.
+            // Spawn uniquement en cours de jeu : en waitingToLaunch la balle a une velocity nulle,
+            // les balles supplémentaires seraient immobiles et ne recevraient jamais la velocity de lancement.
             guard gameState.phase == .playing,
                   let primary = balls.first,
                   let vel = primary.physicsBody?.velocity else { return }
@@ -336,7 +336,7 @@ private extension GameScene {
                 for: .multiBall, ballPosition: primary.position, paddlePosition: paddle.position
             ).forEach(addChild)
         case .instant:
-            break  // New instant types need explicit handling above this line.
+            break  // Les nouveaux types instant nécessitent un traitement explicite ci-dessus.
         case .none:
             break
         }
@@ -353,8 +353,8 @@ private extension GameScene {
         }
     }
 
-    /// Overrides ball velocity based on where it hit the paddle.
-    /// Ignores sub-paddle contacts (physics glitch guard).
+    /// Recalcule la velocity de la balle en fonction du point de contact sur la raquette.
+    /// Ignore les contacts sous la raquette (garde contre les glitches physiques).
     func reflectBallOffPaddle(contactPoint: CGPoint, ball: BallNode) {
         guard contactPoint.y >= paddle.position.y, let body = ball.physicsBody else { return }
         let speed = hypot(body.velocity.dx, body.velocity.dy)
@@ -368,9 +368,10 @@ private extension GameScene {
         )
     }
 
-    func handleBrickContact(_ brick: BrickNode, contactPoint: CGPoint) {
-        let color = brick.color
-        SceneEffects.spawnSparks(at: contactPoint, color: color).forEach(addChild)
+    /// Gère la destruction d'une brique, avec support de la reaction en chaine pour les briques explosives.
+    /// - Parameter isChainReaction: true si la destruction est déclenchée par une explosion voisine (profondeur max = 1).
+    func handleBrickContact(_ brick: BrickNode, contactPoint: CGPoint, isChainReaction: Bool) {
+        SceneEffects.spawnSparks(at: contactPoint, color: brick.color).forEach(addChild)
 
         switch brick.hit() {
         case .intact(let remaining):
@@ -378,6 +379,8 @@ private extension GameScene {
         case .destroyed:
             let points = Theme.Layout.brickPoints
             let spawnPowerUp = !powerUp.isPowerBallActive
+            let wasExplosive = brick.isExplosive
+
             bricks.removeAll { $0 === brick }
             gameState = gameState.addScore(points)
             gameCamera.updateHUD(lives: gameState.lives, score: gameState.score)
@@ -386,17 +389,32 @@ private extension GameScene {
                 guard let self else { return }
                 if bricks.isEmpty && !gameLoop.levelComplete { gameLoop.markLevelComplete() }
             }
+
             if brick.isBonus {
                 addChild(powerUp.spawnGuaranteed(at: brick.position))
             } else if spawnPowerUp, let node = powerUp.spawnIfEligible(at: brick.position) {
                 addChild(node)
+            }
+
+            // Reaction en chaine : détruit toutes les briques adjacentes (profondeur max = 1)
+            if wasExplosive && !isChainReaction {
+                SceneEffects.spawnExplosionBlast(at: contactPoint).forEach(addChild)
+                // Recherche toutes les briques dans les 8 cases voisines (row ±1, col ±1)
+                let neighbors = bricks.filter { other in
+                    abs(other.row - brick.row) <= 1 &&
+                    abs(other.col - brick.col) <= 1 &&
+                    other !== brick
+                }
+                for neighbor in neighbors where !neighbor.isIndestructible {
+                    handleBrickContact(neighbor, contactPoint: neighbor.position, isChainReaction: true)
+                }
             }
         }
     }
 
     func handleLaserContact(_ laser: LaserNode, brick: BrickNode?, contactPoint: CGPoint) {
         laser.removeFromParent()
-        if let brick { handleBrickContact(brick, contactPoint: contactPoint) }
+        if let brick { handleBrickContact(brick, contactPoint: contactPoint, isChainReaction: false) }
     }
 
     func fireLasersIfActive() {

--- a/Sources/Scenes/SceneEffects.swift
+++ b/Sources/Scenes/SceneEffects.swift
@@ -20,6 +20,15 @@ enum SceneEffects {
         ]
     }
 
+    static func spawnExplosionBlast(at position: CGPoint) -> [SKNode] {
+        // Trois anneaux concentriques orange qui s'expandent rapidement lors d'une explosion
+        [
+            rippleRingColored(at: position, delay: 0,    scale: 5.0, alpha: 1.0, lineWidth: 3.0, color: Theme.Color.explosive),
+            rippleRingColored(at: position, delay: 0.05, scale: 7.0, alpha: 0.7, lineWidth: 2.0, color: Theme.Color.explosive),
+            rippleRingColored(at: position, delay: 0.10, scale: 9.0, alpha: 0.4, lineWidth: 1.5, color: Theme.Color.explosive)
+        ]
+    }
+
     static func spawnPowerUpActivationEffect(
         for type: PowerUpType,
         ballPosition: CGPoint,
@@ -83,6 +92,23 @@ enum SceneEffects {
         let ring = RingNode(
             radius: Theme.Layout.ballRadius, delay: delay,
             scale: scale, alpha: alpha, lineWidth: lineWidth
+        )
+        ring.position = position
+        return ring
+    }
+
+    private static func rippleRingColored(
+        at position: CGPoint,
+        delay: TimeInterval,
+        scale: CGFloat,
+        alpha: CGFloat,
+        lineWidth: CGFloat,
+        color: PlatformColor
+    ) -> RingNode {
+        let ring = RingNode(
+            radius: Theme.Layout.ballRadius, delay: delay,
+            scale: scale, alpha: alpha, lineWidth: lineWidth,
+            color: color
         )
         ring.position = position
         return ring


### PR DESCRIPTION
## Summary
- Adds `.explosive` BrickCell type (orange, pulsing `!` icon)
- When destroyed, triggers chain reaction on all 8 adjacent non-indestructible bricks
- Chain reactions do not cascade further (depth limit = 1) to keep gameplay predictable
- Adds `spawnExplosionBlast` visual effect (3 expanding orange rings)
- `RingNode` gains an optional `color` parameter (defaults to `Theme.Color.primary`, fully backward-compatible)
- Explosive bricks placed in levels 2 (HOTSHOT) and 4 (LEGEND)

## Test plan
- [ ] Hit an explosive brick — adjacent bricks should all be destroyed instantly
- [ ] Explosive brick next to another explosive: only depth-1 chain (neighbor destroyed, not further chain)
- [ ] Explosive brick next to indestructible: indestructible survives
- [ ] Points scored = explosive brick + all destroyed neighbors
- [ ] Chain reaction triggers orange ripple blast effect
- [ ] Level 2 (HOTSHOT) and Level 4 (LEGEND) contain explosive bricks