### PR TITLE
feat: regenerating brick with timed rearm (#56)

### DIFF
--- a/Sources/Constants/Theme.swift
+++ b/Sources/Constants/Theme.swift
@@ -41,6 +41,8 @@ enum Theme {
         static let indestructible: PlatformColor = PlatformColor(white: 0.3, alpha: 1.0)
         static let indestructibleBorder: PlatformColor =
             PlatformColor(red: 0.0, green: 0.95, blue: 1.0, alpha: 0.7)
+        static let regenerating: PlatformColor =
+            PlatformColor(red: 0.3, green: 0.9, blue: 0.7, alpha: 1)
         static let brickColors: [PlatformColor] = [
             PlatformColor(red: 1.0, green: 0.35, blue: 0.35, alpha: 1), // coral-red
             PlatformColor(red: 1.0, green: 0.6, blue: 0.1, alpha: 1), // orange

--- a/Sources/Logic/BrickCell.swift
+++ b/Sources/Logic/BrickCell.swift
@@ -4,6 +4,7 @@ enum BrickCell: Equatable {
     case multiHit(Int)
     case indestructible
     case bonus
+    case regenerating
 
     var initialState: BrickState {
         switch self {
@@ -14,13 +15,14 @@ enum BrickCell: Equatable {
             return .intact(hitsRemaining: n)
         case .indestructible: return .intact(hitsRemaining: 1)
         case .bonus: return .intact(hitsRemaining: 1)
+        case .regenerating: return .intact(hitsRemaining: 1)
         }
     }
 }
 
 extension BrickCell: Codable {
     private enum CodingKeys: String, CodingKey { case type, hits }
-    private enum TypeKey: String, Codable { case empty, normal, multiHit, indestructible, bonus }
+    private enum TypeKey: String, Codable { case empty, normal, multiHit, indestructible, bonus, regenerating }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -36,6 +38,8 @@ extension BrickCell: Codable {
             try container.encode(TypeKey.indestructible, forKey: .type)
         case .bonus:
             try container.encode(TypeKey.bonus, forKey: .type)
+        case .regenerating:
+            try container.encode(TypeKey.regenerating, forKey: .type)
         }
     }
 
@@ -48,6 +52,7 @@ extension BrickCell: Codable {
             self = .multiHit(try container.decode(Int.self, forKey: .hits))
         case .indestructible: self = .indestructible
         case .bonus: self = .bonus
+        case .regenerating: self = .regenerating
         }
     }
 }

--- a/Sources/Logic/ContactCoordinator.swift
+++ b/Sources/Logic/ContactCoordinator.swift
@@ -1,0 +1,168 @@
+import SpriteKit
+
+// MARK: - ContactOutcome
+
+/// The subset of contact-event consequences that require `GameScene` to mutate its own state.
+struct ContactOutcome {
+    let pointsScored: Int
+    let lifeAwarded: Bool
+    let extraBallSpawn: (position: CGPoint, velocity: CGVector)?
+
+    init(
+        pointsScored: Int = 0,
+        lifeAwarded: Bool = false,
+        extraBallSpawn: (position: CGPoint, velocity: CGVector)? = nil
+    ) {
+        self.pointsScored = pointsScored
+        self.lifeAwarded = lifeAwarded
+        self.extraBallSpawn = extraBallSpawn
+    }
+}
+
+// MARK: - ContactCoordinator
+
+/// Handles physics contact events on behalf of `GameScene`.
+/// `GameScene.didBegin(_:)` delegates immediately to `handle(_:balls:gamePhase:)`.
+final class ContactCoordinator {
+    private let powerUp: PowerUpCoordinator
+    private let paddle: PaddleNode
+    private let gameLoop: GameLoopCoordinator
+    private let addToScene: ([SKNode]) -> Void
+    private let removeBrick: (BrickNode) -> Void
+    private let remainingBrickCount: () -> Int
+
+    init(
+        powerUp: PowerUpCoordinator,
+        paddle: PaddleNode,
+        gameLoop: GameLoopCoordinator,
+        addToScene: @escaping ([SKNode]) -> Void,
+        removeBrick: @escaping (BrickNode) -> Void,
+        remainingBrickCount: @escaping () -> Int
+    ) {
+        self.powerUp = powerUp
+        self.paddle = paddle
+        self.gameLoop = gameLoop
+        self.addToScene = addToScene
+        self.removeBrick = removeBrick
+        self.remainingBrickCount = remainingBrickCount
+    }
+
+    func handle(
+        _ contact: SKPhysicsContact,
+        balls: [BallNode],
+        gamePhase: GamePhase
+    ) -> ContactOutcome {
+        switch classifyContact(contact) {
+        case .brick(let brick, let point):
+            return handleBrick(brick, contactPoint: point)
+        case .powerUp(let node):
+            return handlePowerUp(node, balls: balls, gamePhase: gamePhase)
+        case .paddleHit(let ball, let point):
+            if gamePhase != .waitingToLaunch { paddle.squash() }
+            if let ball { reflectBallOffPaddle(contactPoint: point, ball: ball) }
+            return ContactOutcome()
+        case .wallHit(let wall):
+            wall.flash()
+            return ContactOutcome()
+        case .laser(let laser, let brick, let point):
+            return handleLaser(laser, brick: brick, contactPoint: point)
+        case .unknown:
+            return ContactOutcome()
+        }
+    }
+}
+
+// MARK: - Contact handlers
+// Internal (not private) so @testable imports in ContactCoordinatorTests can call handlers directly.
+extension ContactCoordinator {
+    func handleBrick(_ brick: BrickNode, contactPoint: CGPoint) -> ContactOutcome {
+        addToScene(SceneEffects.spawnSparks(at: contactPoint, color: brick.color))
+        switch brick.hit() {
+        case .intact(let remaining):
+            brick.applyDamage(remainingHits: remaining)
+            return ContactOutcome()
+        case .destroyed:
+            let points = Theme.Layout.brickPoints
+            let spawnPowerUp = !powerUp.isPowerBallActive
+
+            // Les briques régénérantes ne sont pas retirées de la scène ni du tableau `bricks` :
+            // elles disparaissent temporairement puis reviennent après un délai.
+            if brick.isRegenerating {
+                brick.beginRegeneration()
+                addToScene(SceneEffects.spawnScorePopup(at: contactPoint, points: points))
+                return ContactOutcome(pointsScored: points)
+            }
+
+            removeBrick(brick)
+            brick.destroy { [weak self] in
+                guard let self else { return }
+                if remainingBrickCount() == 0 && !gameLoop.levelComplete {
+                    gameLoop.markLevelComplete()
+                }
+            }
+            var nodesToAdd = SceneEffects.spawnScorePopup(at: contactPoint, points: points)
+            if brick.isBonus {
+                nodesToAdd.append(powerUp.spawnGuaranteed(at: brick.position))
+            } else if spawnPowerUp, let node = powerUp.spawnIfEligible(at: brick.position) {
+                nodesToAdd.append(node)
+            }
+            addToScene(nodesToAdd)
+            return ContactOutcome(pointsScored: points)
+        }
+    }
+
+    func handlePowerUp(
+        _ node: PowerUpNode,
+        balls: [BallNode],
+        gamePhase: GamePhase
+    ) -> ContactOutcome {
+        let ballPos = balls.first?.position ?? paddle.position
+        switch powerUp.collect(node) {
+        case .activated(let type):
+            addToScene(SceneEffects.spawnPowerUpActivationEffect(
+                for: type, ballPosition: ballPos, paddlePosition: paddle.position
+            ))
+            return ContactOutcome()
+        case .instant(.extraLife):
+            addToScene(SceneEffects.spawnPowerUpActivationEffect(
+                for: .extraLife, ballPosition: ballPos, paddlePosition: paddle.position
+            ))
+            return ContactOutcome(lifeAwarded: true)
+        case .instant(.multiBall):
+            guard gamePhase == .playing,
+                  let primary = balls.first,
+                  let vel = primary.physicsBody?.velocity else { return ContactOutcome() }
+            addToScene(SceneEffects.spawnPowerUpActivationEffect(
+                for: .multiBall, ballPosition: primary.position, paddlePosition: paddle.position
+            ))
+            return ContactOutcome(extraBallSpawn: (position: primary.position, velocity: vel))
+        case .instant:
+            return ContactOutcome()
+        case .none:
+            return ContactOutcome()
+        }
+    }
+
+    func handleLaser(
+        _ laser: LaserNode,
+        brick: BrickNode?,
+        contactPoint: CGPoint
+    ) -> ContactOutcome {
+        laser.removeFromParent()
+        guard let brick else { return ContactOutcome() }
+        return handleBrick(brick, contactPoint: contactPoint)
+    }
+
+    func reflectBallOffPaddle(contactPoint: CGPoint, ball: BallNode) {
+        guard contactPoint.y >= paddle.position.y, let body = ball.physicsBody else { return }
+        let speed = hypot(body.velocity.dx, body.velocity.dy)
+        let halfWidth = paddle.size.width * paddle.xScale / 2
+        body.velocity = paddleReflectedVelocity(
+            speed: speed,
+            contactX: contactPoint.x,
+            paddleCenterX: paddle.position.x,
+            halfPaddleWidth: halfWidth,
+            maxAngle: Theme.Layout.paddleMaxAngle
+        )
+    }
+}

--- a/Sources/Logic/Level.swift
+++ b/Sources/Logic/Level.swift
@@ -2,6 +2,7 @@ private let e: BrickCell = .empty
 private let n: BrickCell = .normal
 private let i: BrickCell = .indestructible
 private let b: BrickCell = .bonus
+private let r: BrickCell = .regenerating
 private func m(_ hits: Int) -> BrickCell { .multiHit(hits) }
 
 struct Level {
@@ -12,7 +13,6 @@ struct Level {
         grid.flatMap { $0 }.filter { $0 != .empty && $0 != .indestructible }.count
     }
 
-    // 5 rows × 10 columns, fully packed — 48 normal + 2 bonus = 50 bricks
     static let one = Level(name: "ROOKIE", grid: [
         [n, n, n, n, n, n, n, n, n, n],
         [n, n, n, n, n, n, n, n, n, n],
@@ -21,7 +21,6 @@ struct Level {
         [n, n, n, n, n, n, n, n, n, n]
     ])
 
-    // 8 rows × 10 columns, checkerboard — 40 bricks
     static let two = Level(name: "HOTSHOT", grid: [
         [n, e, n, e, n, e, n, e, n, e],
         [e, n, e, n, e, n, e, n, e, n],
@@ -33,20 +32,19 @@ struct Level {
         [e, n, e, n, e, n, e, n, e, n]
     ])
 
-    // 9 rows × 10 columns, diamond — 2 bonus at each tip, center row has 3-hit bricks — 50 bricks
+    // Diamond avec 2 briques régénérantes au centre
     static let three = Level(name: "ACE", grid: [
         [e, e, e, e, b, b, e, e, e, e],
         [e, e, e, n, n, n, n, e, e, e],
         [e, e, n, n, n, n, n, n, e, e],
         [e, n, n, n, n, n, n, n, n, e],
-        [n, n, n, n, m(3), m(3), n, n, n, n],
+        [n, n, n, n, r, r, n, n, n, n],
         [e, n, n, n, n, n, n, n, n, e],
         [e, e, n, n, n, n, n, n, e, e],
         [e, e, e, n, n, n, n, e, e, e],
         [e, e, e, e, b, b, e, e, e, e]
     ])
 
-    // 7 rows × 10 columns, fully packed — top row has 2-hit bricks — 70 bricks total
     static let four = Level(name: "LEGEND", grid: [
         [m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2)],
         [n, n, n, n, n, n, n, n, n, n],
@@ -57,14 +55,14 @@ struct Level {
         [n, n, n, n, n, n, n, n, n, n]
     ])
 
-    // 10 rows × 10 columns, symmetric labyrinth — 44 bricks
+    // Labyrinthe avec 4 briques régénérantes dans les coins intérieurs
     static let five = Level(name: "MAZE", grid: [
         [n, n, n, i, i, i, i, n, n, n],
         [n, e, e, e, e, e, e, e, e, n],
         [n, e, n, n, e, e, n, n, e, n],
         [i, e, n, e, n, n, e, n, e, i],
-        [i, e, n, e, m(2), m(2), e, n, e, i],
-        [i, e, n, e, m(2), m(2), e, n, e, i],
+        [i, e, n, e, r, r, e, n, e, i],
+        [i, e, n, e, r, r, e, n, e, i],
         [i, e, n, e, n, n, e, n, e, i],
         [n, e, n, n, e, e, n, n, e, n],
         [n, e, e, e, e, e, e, e, e, n],

--- a/Sources/Nodes/BrickNode.swift
+++ b/Sources/Nodes/BrickNode.swift
@@ -5,14 +5,15 @@ final class BrickNode: SKSpriteNode {
     let col: Int
     let isIndestructible: Bool
     let isBonus: Bool
+    let isRegenerating: Bool
     private var brickState: BrickState
     private let initialHits: Int
     private var hitHandled = false
 
     var currentCell: BrickCell {
         if isIndestructible { return .indestructible }
-        // Only report .bonus while intact; destroyed falls through to .empty via brickState.asCell
         if isBonus, case .intact = brickState { return .bonus }
+        if isRegenerating, case .intact = brickState { return .regenerating }
         return brickState.asCell
     }
 
@@ -21,14 +22,20 @@ final class BrickNode: SKSpriteNode {
         self.col = col
         self.isIndestructible = (cell == .indestructible)
         self.isBonus = (cell == .bonus)
+        self.isRegenerating = (cell == .regenerating)
         self.brickState = cell.initialState
         switch self.brickState {
         case .intact(let n): self.initialHits = n
         case .destroyed: self.initialHits = 1
         }
-        let rowColor = isIndestructible
-            ? Theme.Color.indestructible
-            : Theme.Color.brickColors[row % Theme.Color.brickColors.count]
+        let rowColor: PlatformColor
+        if isIndestructible {
+            rowColor = Theme.Color.indestructible
+        } else if isRegenerating {
+            rowColor = Theme.Color.regenerating
+        } else {
+            rowColor = Theme.Color.brickColors[row % Theme.Color.brickColors.count]
+        }
         super.init(texture: nil, color: rowColor, size: size)
         addChild(ShadowNode.makeBrickShadow(size: size, color: rowColor))
         let body = SKPhysicsBody(rectangleOf: size)
@@ -52,7 +59,6 @@ final class BrickNode: SKSpriteNode {
 
         if isIndestructible {
             addChild(makeHatchNode(size: size))
-
             let border = SKShapeNode(rectOf: size)
             border.fillColor = .clear
             border.strokeColor = Theme.Color.indestructibleBorder
@@ -66,6 +72,10 @@ final class BrickNode: SKSpriteNode {
 
         if isBonus {
             makeBonusOverlayNodes(size: size).forEach(addChild)
+        }
+
+        if isRegenerating {
+            makeRegeneratingOverlayNodes(size: size).forEach(addChild)
         }
 
         addBevelOverlays(size: size)
@@ -116,11 +126,62 @@ final class BrickNode: SKSpriteNode {
         let done = SKAction.run(completion)
         run(.sequence([firstPhase, secondPhase, done, remove]))
     }
+
+    /// Démarre la phase de régénération : retire le corps physique, pulse à 12% d'opacité,
+    /// puis remet la brique en jeu après 4 secondes.
+    func beginRegeneration() {
+        physicsBody = nil
+        // Réinitialise la rotation issue des animations d'impact
+        removeAllActions()
+        xScale = 1.0
+        yScale = 1.0
+        zRotation = 0
+
+        let fadeOut = SKAction.fadeAlpha(to: 0.12, duration: 0.25)
+        let pulse = SKAction.repeatForever(.sequence([
+            .fadeAlpha(to: 0.20, duration: 0.6),
+            .fadeAlpha(to: 0.06, duration: 0.6)
+        ]))
+        let startPulse = SKAction.run { [weak self] in
+            self?.run(pulse, withKey: "regen-pulse")
+        }
+        let wait = SKAction.wait(forDuration: 4.0)
+        let rearmAction = SKAction.run { [weak self] in self?.rearm() }
+
+        run(.sequence([fadeOut, startPulse, wait, rearmAction]), withKey: "regeneration")
+    }
 }
 
 // MARK: - Private helpers
 
 private extension BrickNode {
+    func rearm() {
+        removeAction(forKey: "regen-pulse")
+        removeAction(forKey: "regeneration")
+
+        // Remet l'état interne à intact
+        brickState = .intact(hitsRemaining: 1)
+
+        // Animation de réapparition : flash blanc puis retour à la couleur d'origine
+        let fadeIn = SKAction.fadeAlpha(to: 1.0, duration: 0.20)
+        let flashIn = SKAction.colorize(with: .white, colorBlendFactor: 0.9, duration: 0.08)
+        let resetColor = SKAction.colorize(withColorBlendFactor: 0.0, duration: 0.25)
+        let scaleIn = SKAction.sequence([
+            .scale(to: 1.12, duration: 0.08),
+            .scale(to: 1.0, duration: 0.12)
+        ])
+        run(.group([fadeIn, .sequence([flashIn, resetColor]), scaleIn]))
+
+        // Restaure le corps physique
+        let body = SKPhysicsBody(rectangleOf: size)
+        body.isDynamic = false
+        body.restitution = 1
+        body.friction = 0
+        body.categoryBitMask = PhysicsCategory.brick
+        body.contactTestBitMask = PhysicsCategory.ball
+        physicsBody = body
+    }
+
     func deflect() {
         let flash = SKAction.colorize(with: .white, colorBlendFactor: 0.5, duration: 0.04)
         let recover = SKAction.colorize(withColorBlendFactor: 0.0, duration: 0.12)
@@ -195,4 +256,26 @@ private func makeBonusOverlayNodes(size: CGSize) -> [SKNode] {
     star.horizontalAlignmentMode = .center
 
     return [border, star]
+}
+
+private func makeRegeneratingOverlayNodes(size: CGSize) -> [SKNode] {
+    // Bordure turquoise qui pulse lentement pour indiquer la régénération
+    let border = SKShapeNode(rectOf: size)
+    border.fillColor = .clear
+    border.strokeColor = Theme.Color.regenerating
+    border.lineWidth = 1.5
+    border.run(.repeatForever(.sequence([
+        .fadeAlpha(to: 0.3, duration: 0.7),
+        .fadeAlpha(to: 1.0, duration: 0.7)
+    ])))
+
+    // Icône "↺" pour indiquer la régénération
+    let icon = SKLabelNode(fontNamed: Theme.Font.bold)
+    icon.text = "↺"
+    icon.fontSize = 9
+    icon.fontColor = .white
+    icon.verticalAlignmentMode = .center
+    icon.horizontalAlignmentMode = .center
+
+    return [border, icon]
 }


### PR DESCRIPTION
## Summary
- Adds `.regenerating` BrickCell type (teal color, `↺` icon)  
- When destroyed: removes physics body, pulses at low opacity (12%), regenerates after 4 seconds
- On rearm: physics body restored, state reset to `intact(hitsRemaining: 1)`, white flash animation
- Points scored on initial destruction (same as normal bricks)
- Brick stays in `GameScene.bricks` during regeneration — level not considered complete while regenerating bricks exist
- Placed in level 3 (ACE) center row and level 5 (MAZE) center cluster

## Test plan
- [ ] Hit a regenerating brick — it disappears and pulses at low opacity
- [ ] After ~4 seconds, it flashes white and becomes hittable again
- [ ] Points scored on destruction, not on regeneration
- [ ] Level cannot be completed while regenerating bricks are in the scene
- [ ] Hitting a rearming brick again restarts the regeneration cycle
- [ ] Laser also triggers regeneration (not hard removal)