### PR TITLE
fix: power ball bounces off indestructible bricks (#72)

### DIFF
--- a/Sources/Constants/PhysicsCategory.swift
+++ b/Sources/Constants/PhysicsCategory.swift
@@ -5,4 +5,5 @@ enum PhysicsCategory {
     static let brick: UInt32 = 0x1 << 3
     static let powerUp: UInt32 = 0x1 << 4
     static let laser: UInt32 = 0x1 << 5
+    static let indestructibleBrick: UInt32 = 0x1 << 6
 }

--- a/Sources/Nodes/BallNode.swift
+++ b/Sources/Nodes/BallNode.swift
@@ -59,7 +59,8 @@ final class BallNode: SKNode {
         body.allowsRotation = false
         body.categoryBitMask = PhysicsCategory.ball
         body.collisionBitMask =
-            PhysicsCategory.wall | PhysicsCategory.paddle | PhysicsCategory.brick
+            PhysicsCategory.wall | PhysicsCategory.paddle
+            | PhysicsCategory.brick | PhysicsCategory.indestructibleBrick
         return body
     }
 
@@ -116,7 +117,8 @@ final class BallNode: SKNode {
 
     func activatePowerBall() {
         isPowerBall = true
-        physicsBody?.collisionBitMask = PhysicsCategory.wall | PhysicsCategory.paddle
+        physicsBody?.collisionBitMask =
+            PhysicsCategory.wall | PhysicsCategory.paddle | PhysicsCategory.indestructibleBrick
         shape.fillColor = Theme.Color.powerUp
         bloom.filter?.setValue(16.0, forKey: "inputRadius")
         trail.activate(color: Theme.Color.powerUp)
@@ -143,7 +145,8 @@ final class BallNode: SKNode {
     func deactivatePowerBall() {
         isPowerBall = false
         physicsBody?.collisionBitMask =
-            PhysicsCategory.wall | PhysicsCategory.paddle | PhysicsCategory.brick
+            PhysicsCategory.wall | PhysicsCategory.paddle
+            | PhysicsCategory.brick | PhysicsCategory.indestructibleBrick
         shape.fillColor = Theme.Color.primary
         bloom.filter?.setValue(8.0, forKey: "inputRadius")
         trail.deactivate()

--- a/Sources/Nodes/BrickNode.swift
+++ b/Sources/Nodes/BrickNode.swift
@@ -39,7 +39,8 @@ final class BrickNode: SKSpriteNode {
         let rowColor = BrickNode.brickColor(cell: cell, row: row, isArmored: self.isArmored)
         super.init(texture: nil, color: rowColor, size: size)
         addChild(ShadowNode.makeBrickShadow(size: size, color: rowColor))
-        physicsBody = BrickNode.makeBrickPhysicsBody(size: size)
+        physicsBody = BrickNode.makeBrickPhysicsBody(
+            size: size, isIndestructible: self.isIndestructible)
         if case .multiHit(let n) = cell { addChild(makeHitLabel(n: n, size: size)) }
         addTypeOverlays(cell: cell, size: size)
         addBevelOverlays(size: size)
@@ -85,7 +86,7 @@ final class BrickNode: SKSpriteNode {
         guard isRegenerating else { return }
         isRearming = false
         brickState = .intact(hitsRemaining: 1)
-        physicsBody = BrickNode.makeBrickPhysicsBody(size: size)
+        physicsBody = BrickNode.makeBrickPhysicsBody(size: size, isIndestructible: false)
         let flash = SKAction.colorize(with: .white, colorBlendFactor: 1.0, duration: 0.08)
         let restore = SKAction.colorize(withColorBlendFactor: 0.0, duration: 0.15)
         let fadeIn = SKAction.fadeAlpha(to: 1.0, duration: 0.15)
@@ -206,12 +207,16 @@ private extension BrickNode {
 // MARK: - Private helpers
 
 extension BrickNode {
-    private static func makeBrickPhysicsBody(size: CGSize) -> SKPhysicsBody {
+    private static func makeBrickPhysicsBody(
+        size: CGSize, isIndestructible: Bool
+    ) -> SKPhysicsBody {
         let body = SKPhysicsBody(rectangleOf: size)
         body.isDynamic = false
         body.restitution = 1
         body.friction = 0
-        body.categoryBitMask = PhysicsCategory.brick
+        body.categoryBitMask = isIndestructible
+            ? PhysicsCategory.indestructibleBrick
+            : PhysicsCategory.brick
         body.contactTestBitMask = PhysicsCategory.ball
         return body
     }

--- a/Sources/Nodes/LaserNode.swift
+++ b/Sources/Nodes/LaserNode.swift
@@ -19,6 +19,7 @@ final class LaserNode: SKShapeNode {
         body.linearDamping = 0
         body.categoryBitMask    = PhysicsCategory.laser
         body.collisionBitMask   = 0
+        // indestructibleBrick excluded — lasers pass through permanent bricks
         body.contactTestBitMask = PhysicsCategory.brick | PhysicsCategory.wall
         physicsBody = body
     }


### PR DESCRIPTION
## Summary

- Added `PhysicsCategory.indestructibleBrick` (`0x1 << 6`) to give permanent bricks their own physics category
- `BrickNode.makeBrickPhysicsBody` now assigns the correct category based on `isIndestructible`
- `BallNode.activatePowerBall` keeps `indestructibleBrick` in the collision mask (ball bounces) but drops `brick` (ball passes through)
- `BallNode.deactivatePowerBall` and `makePhysicsBody` both include both brick categories — normal ball bounces off everything
- Added a clarifying comment in `LaserNode` noting that lasers intentionally pass through indestructible bricks

Closes #72

## Test plan

- [ ] Power ball smashes through destructible bricks without bouncing
- [ ] Power ball bounces off indestructible bricks
- [ ] Normal ball bounces off all brick types
- [ ] Level 5 (MAZE) indestructible-brick walls behave correctly with power ball active
- [ ] All tests pass (`scripts/build.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)