### PR TITLE
refactor: tighten audioComboCounter to private(set), closes #78

### DIFF
--- a/Sources/Audio/SoundCoordinator.swift
+++ b/Sources/Audio/SoundCoordinator.swift
@@ -23,8 +23,8 @@ final class SoundCoordinator {
     private let powerUpNode = AVAudioPlayerNode()
 
     // Audio-combo state for pitch boost (independent from scoring combo).
-    // Internal (not private) so @testable unit tests can inspect the counter.
-    var audioComboCounter = 0
+    // private(set) so @testable unit tests can read but not write the counter.
+    private(set) var audioComboCounter = 0
     private var audioLastHitTime: TimeInterval = 0
 
     private let defaults: UserDefaults


### PR DESCRIPTION
## Summary

- Change `audioComboCounter` from `var` to `private(set) var` in `SoundCoordinator`
- Tests only read the counter via `@testable import` — no write access needed externally
- Prevents accidental external mutation while keeping the value observable in tests

## Test plan

- [ ] Existing `SoundCoordinatorTests` still compile and pass (counter reads are unchanged)
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)