### PR TITLE
refactor: simplify branch detection in guard-main-branch.sh, closes #80

### DIFF
--- a/.claude/hooks/guard-main-branch.sh
+++ b/.claude/hooks/guard-main-branch.sh
@@ -5,7 +5,7 @@
 command=$(jq -r '.tool_input.command // empty')
 
 if echo "$command" | grep -q 'git commit'; then
-  branch=$(git -C "$(dirname "$0")/../.." rev-parse --abbrev-ref HEAD 2>/dev/null)
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
   if [ "$branch" = "main" ]; then
     echo "BLOCKED: You are on the main branch."
     echo "Create a feature branch first:"


### PR DESCRIPTION
## Summary

- Remove `-C "$(dirname "$0")/../.."` path arithmetic from `guard-main-branch.sh`
- Use plain `git rev-parse --abbrev-ref HEAD` instead — works correctly since Claude Code hooks always run with the project root as CWD

## Test plan

- [ ] Committing directly to `main` is still blocked
- [ ] Committing on a feature branch proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)