### PR TITLE
fix: annotate ContactCoordinator with @MainActor

### DIFF
--- a/Sources/Logic/ContactCoordinator.swift
+++ b/Sources/Logic/ContactCoordinator.swift
@@ -29,6 +29,7 @@ struct ContactOutcome {
 
 /// Handles physics contact events on behalf of `GameScene`.
 /// `GameScene.didBegin(_:)` delegates immediately to `handle(_:balls:gamePhase:)`.
+@MainActor
 final class ContactCoordinator {
     private let powerUp: PowerUpCoordinator
     private let paddle: PaddleNode

--- a/Tests/ContactCoordinatorTests.swift
+++ b/Tests/ContactCoordinatorTests.swift
@@ -2,6 +2,7 @@
 import SpriteKit
 import Testing
 
+@MainActor
 @Suite("ContactCoordinator")
 // swiftlint:disable:next type_body_length
 struct ContactCoordinatorTests {


### PR DESCRIPTION
## Summary

- `SoundCoordinator` is `@MainActor`-isolated; `ContactCoordinator` called `playPaddleHit()`, `playWallHit()`, and `playBrickHit(row:totalRows:)` from a nonisolated context, breaking the build
- Annotating `ContactCoordinator` with `@MainActor` is correct — it is always created and used from `GameScene`, which runs on the main thread, and `didBegin(_:)` is dispatched on the main thread by SpriteKit
- `ContactCoordinatorTests` gets the same annotation so the test suite can call the now-isolated methods

## Test plan

- [x] `scripts/build.sh` passes (build + lint)
- [x] All `ContactCoordinator` tests pass
- Note: two pre-existing `SoundCoordinatorTests` failures (`updateAudioCombo_rapidHits_incrementsCounter`, `updateAudioCombo_multipleRapidHits_accumulatesCounter`) are tracked in #83 and are not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)