### PR TITLE
feat: in-game mute toggle on HUD, closes #52

### DIFF
--- a/Sources/Audio/SoundCoordinator.swift
+++ b/Sources/Audio/SoundCoordinator.swift
@@ -58,6 +58,10 @@ final class SoundCoordinator {
         }
     }
 
+    func toggleMute() {
+        isMuted.toggle()
+    }
+
     func stopEngine() {
         engine.stop()
         #if os(iOS)

--- a/Sources/Constants/Theme.swift
+++ b/Sources/Constants/Theme.swift
@@ -59,6 +59,8 @@ enum Theme {
 
     enum Symbol {
         static let pause = "II"
+        static let soundOn  = "♪"
+        static let soundOff = "✕"
     }
 
     enum Layout {
@@ -77,6 +79,7 @@ enum Theme {
         static let brickPoints: Int = 10
         static let hudTopPadding: CGFloat = 8
         static let hudSideMargin: CGFloat = 16
+        static let hudButtonSpacing: CGFloat = 36
         static let highScoreOffsetY: CGFloat = -30
         static let splashButtonSpacing: CGFloat = 44
         static let powerUpSize: CGSize = CGSize(width: 34, height: 14)

--- a/Sources/Input/InputCoordinator.swift
+++ b/Sources/Input/InputCoordinator.swift
@@ -4,17 +4,28 @@ enum InputAction: Equatable {
     case none
     case pause
     case resume
+    case toggleMute
     case movePaddle(x: CGFloat)
     case launchAndMovePaddle(x: CGFloat)
 }
 
 struct InputCoordinator {
-    func action(at location: CGPoint, hittingPauseButton: Bool, phase: GamePhase) -> InputAction {
-        let intent = touchIntent(hitsPauseButton: hittingPauseButton, phase: phase)
+    func action(
+        at location: CGPoint,
+        hittingPauseButton: Bool,
+        hittingMuteButton: Bool,
+        phase: GamePhase
+    ) -> InputAction {
+        let intent = touchIntent(
+            hitsPauseButton: hittingPauseButton,
+            hitsMuteButton: hittingMuteButton,
+            phase: phase
+        )
         switch intent {
         case .none:                return .none
         case .pause:               return .pause
         case .resume:              return .resume
+        case .toggleMute:          return .toggleMute
         case .movePaddle:          return .movePaddle(x: location.x)
         case .launchAndMovePaddle: return .launchAndMovePaddle(x: location.x)
         }

--- a/Sources/Logic/TouchIntent.swift
+++ b/Sources/Logic/TouchIntent.swift
@@ -1,17 +1,24 @@
 enum TouchIntent {
     case pause
     case resume
+    case toggleMute
     case launchAndMovePaddle
     case movePaddle
     case none
 }
 
-func touchIntent(hitsPauseButton: Bool, phase: GamePhase) -> TouchIntent {
+func touchIntent(hitsPauseButton: Bool, hitsMuteButton: Bool, phase: GamePhase) -> TouchIntent {
     if hitsPauseButton {
         switch phase {
         case .playing: return .pause
         case .paused:  return .resume
         default:       return .none
+        }
+    }
+    if hitsMuteButton {
+        switch phase {
+        case .waitingToLaunch, .playing: return .toggleMute
+        default:                         return .none
         }
     }
     switch phase {

--- a/Sources/Nodes/GameCameraNode.swift
+++ b/Sources/Nodes/GameCameraNode.swift
@@ -22,6 +22,10 @@ final class GameCameraNode: SKCameraNode {
         hud.update(lives: lives, score: score, comboMultiplier: comboMultiplier)
     }
 
+    func updateMuteButton(isMuted: Bool) {
+        hud.setMuted(isMuted)
+    }
+
     func setPaused(_ isPaused: Bool) {
         pauseOverlay.isHidden = !isPaused
     }

--- a/Sources/Nodes/HUDNode.swift
+++ b/Sources/Nodes/HUDNode.swift
@@ -4,6 +4,7 @@ final class HUDNode: SKNode {
     private let livesLabel: SKLabelNode
     private let scoreLabel: SKLabelNode
     private let pauseButton: SKLabelNode
+    private let muteButton: SKLabelNode
     private let comboLabel: SKLabelNode
     private var lastScore: Int = 0
     private var lastComboMultiplier: Int = 1
@@ -12,6 +13,7 @@ final class HUDNode: SKNode {
         livesLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         scoreLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         pauseButton = SKLabelNode.makeBody(Theme.Symbol.pause, color: Theme.Color.primary)
+        muteButton = SKLabelNode.makeBody(Theme.Symbol.soundOn, color: Theme.Color.primary)
         comboLabel = SKLabelNode.makeBody("", color: Theme.Color.danger)
         super.init()
         let hudY = sceneSize.height / 2 - topSafeArea - Theme.Layout.hudTopPadding
@@ -21,13 +23,24 @@ final class HUDNode: SKNode {
         pauseButton.horizontalAlignmentMode = .right
         pauseButton.position = CGPoint(x: sceneSize.width / 2 - Theme.Layout.hudSideMargin, y: hudY)
         pauseButton.name = "pauseButton"
+        muteButton.horizontalAlignmentMode = .right
+        muteButton.position = CGPoint(
+            x: sceneSize.width / 2 - Theme.Layout.hudSideMargin - Theme.Layout.hudButtonSpacing,
+            y: hudY
+        )
+        muteButton.name = "muteButton"
         // Combo label sits below the score, hidden while multiplier is ×1
         comboLabel.position = CGPoint(x: 0, y: hudY + Theme.Layout.highScoreOffsetY)
         comboLabel.alpha = 0
         addChild(livesLabel)
         addChild(scoreLabel)
         addChild(pauseButton)
+        addChild(muteButton)
         addChild(comboLabel)
+    }
+
+    func setMuted(_ muted: Bool) {
+        muteButton.text = muted ? Theme.Symbol.soundOff : Theme.Symbol.soundOn
     }
 
     func update(lives: Int, score: Int, comboMultiplier: Int = 1) {

--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -63,6 +63,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         addChild(cam)
         camera = cam
         cam.updateHUD(lives: gameState.lives, score: gameState.score)
+        cam.updateMuteButton(isMuted: sound.isMuted)
     }
 
     private func configurePhysics() {
@@ -154,6 +155,9 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         case .resume:
             gameState = gameState.resume()
             applyPauseState()
+        case .toggleMute:
+            sound.toggleMute()
+            gameCamera.updateMuteButton(isMuted: sound.isMuted)
         case .movePaddle(let x):
             movePaddle(to: x)
         case .launchAndMovePaddle(let x):
@@ -187,9 +191,11 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         }
         guard let touch = touches.first else { return }
         let loc = touch.location(in: self)
+        let hitNodes = nodes(at: loc)
         handle(inputCoordinator.action(
             at: loc,
-            hittingPauseButton: nodes(at: loc).contains { $0.name == "pauseButton" },
+            hittingPauseButton: hitNodes.contains { $0.name == "pauseButton" },
+            hittingMuteButton: hitNodes.contains { $0.name == "muteButton" },
             phase: gameState.phase
         ))
         if gameState.phase == .playing { fireLasersIfActive() }
@@ -210,9 +216,11 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
 
     override func mouseDown(with event: NSEvent) {
         let loc = event.location(in: self)
+        let hitNodes = nodes(at: loc)
         handle(inputCoordinator.action(
             at: loc,
-            hittingPauseButton: nodes(at: loc).contains { $0.name == "pauseButton" },
+            hittingPauseButton: hitNodes.contains { $0.name == "pauseButton" },
+            hittingMuteButton: hitNodes.contains { $0.name == "muteButton" },
             phase: gameState.phase
         ))
     }

--- a/Tests/InputCoordinatorTests.swift
+++ b/Tests/InputCoordinatorTests.swift
@@ -6,33 +6,55 @@ struct InputCoordinatorTests {
     private let coordinator = InputCoordinator()
 
     @Test func movePaddle_carriesLocationX() {
-        let action = coordinator.action(at: CGPoint(x: 123, y: 0),
-                                        hittingPauseButton: false,
-                                        phase: .playing)
+        let action = coordinator.action(
+            at: CGPoint(x: 123, y: 0), hittingPauseButton: false, hittingMuteButton: false,
+            phase: .playing
+        )
         #expect(action == .movePaddle(x: 123))
     }
 
     @Test func launchAndMovePaddle_carriesLocationX() {
-        let action = coordinator.action(at: CGPoint(x: 77, y: 0),
-                                        hittingPauseButton: false,
-                                        phase: .waitingToLaunch)
+        let action = coordinator.action(
+            at: CGPoint(x: 77, y: 0), hittingPauseButton: false, hittingMuteButton: false,
+            phase: .waitingToLaunch
+        )
         #expect(action == .launchAndMovePaddle(x: 77))
     }
 
     @Test func pause_whenHittingPauseButtonWhilePlaying() {
-        let action = coordinator.action(at: .zero, hittingPauseButton: true, phase: .playing)
+        let action = coordinator.action(
+            at: .zero, hittingPauseButton: true, hittingMuteButton: false, phase: .playing
+        )
         #expect(action == .pause)
     }
 
     @Test func resume_whenHittingPauseButtonWhilePaused() {
-        let action = coordinator.action(at: .zero, hittingPauseButton: true, phase: .paused)
+        let action = coordinator.action(
+            at: .zero, hittingPauseButton: true, hittingMuteButton: false, phase: .paused
+        )
         #expect(action == .resume)
     }
 
     @Test func none_whenGameOver() {
-        let action = coordinator.action(at: CGPoint(x: 50, y: 0),
-                                        hittingPauseButton: false,
-                                        phase: .gameOver)
+        let action = coordinator.action(
+            at: CGPoint(x: 50, y: 0), hittingPauseButton: false, hittingMuteButton: false,
+            phase: .gameOver
+        )
         #expect(action == .none)
+    }
+
+    @Test func toggleMute_whenHittingMuteButtonWhilePlaying() {
+        let action = coordinator.action(
+            at: .zero, hittingPauseButton: false, hittingMuteButton: true, phase: .playing
+        )
+        #expect(action == .toggleMute)
+    }
+
+    @Test func toggleMute_whenHittingMuteButtonWhileWaiting() {
+        let action = coordinator.action(
+            at: .zero, hittingPauseButton: false, hittingMuteButton: true,
+            phase: .waitingToLaunch
+        )
+        #expect(action == .toggleMute)
     }
 }

--- a/Tests/TouchIntentTests.swift
+++ b/Tests/TouchIntentTests.swift
@@ -4,42 +4,68 @@ import Testing
 struct TouchIntentTests {
 
     @Test func touchIntent_pauseButton_whilePlaying_returnsPause() {
-        let intent = touchIntent(hitsPauseButton: true, phase: .playing)
+        let intent = touchIntent(hitsPauseButton: true, hitsMuteButton: false, phase: .playing)
         #expect(intent == .pause)
     }
 
     @Test func touchIntent_pauseButton_whilePaused_returnsResume() {
-        let intent = touchIntent(hitsPauseButton: true, phase: .paused)
+        let intent = touchIntent(hitsPauseButton: true, hitsMuteButton: false, phase: .paused)
         #expect(intent == .resume)
     }
 
     @Test func touchIntent_pauseButton_whileWaiting_returnsNone() {
-        let intent = touchIntent(hitsPauseButton: true, phase: .waitingToLaunch)
+        let intent = touchIntent(
+            hitsPauseButton: true, hitsMuteButton: false, phase: .waitingToLaunch
+        )
         #expect(intent == .none)
     }
 
     @Test func touchIntent_pauseButton_whileGameOver_returnsNone() {
-        let intent = touchIntent(hitsPauseButton: true, phase: .gameOver)
+        let intent = touchIntent(hitsPauseButton: true, hitsMuteButton: false, phase: .gameOver)
         #expect(intent == .none)
     }
 
     @Test func touchIntent_normalTouch_whilePaused_returnsNone() {
-        let intent = touchIntent(hitsPauseButton: false, phase: .paused)
+        let intent = touchIntent(hitsPauseButton: false, hitsMuteButton: false, phase: .paused)
         #expect(intent == .none)
     }
 
     @Test func touchIntent_normalTouch_whileWaiting_returnsLaunchAndMove() {
-        let intent = touchIntent(hitsPauseButton: false, phase: .waitingToLaunch)
+        let intent = touchIntent(
+            hitsPauseButton: false, hitsMuteButton: false, phase: .waitingToLaunch
+        )
         #expect(intent == .launchAndMovePaddle)
     }
 
     @Test func touchIntent_normalTouch_whilePlaying_returnsMove() {
-        let intent = touchIntent(hitsPauseButton: false, phase: .playing)
+        let intent = touchIntent(hitsPauseButton: false, hitsMuteButton: false, phase: .playing)
         #expect(intent == .movePaddle)
     }
 
     @Test func touchIntent_normalTouch_whileGameOver_returnsNone() {
-        let intent = touchIntent(hitsPauseButton: false, phase: .gameOver)
+        let intent = touchIntent(hitsPauseButton: false, hitsMuteButton: false, phase: .gameOver)
+        #expect(intent == .none)
+    }
+
+    @Test func touchIntent_muteButton_whilePlaying_returnsToggleMute() {
+        let intent = touchIntent(hitsPauseButton: false, hitsMuteButton: true, phase: .playing)
+        #expect(intent == .toggleMute)
+    }
+
+    @Test func touchIntent_muteButton_whileWaiting_returnsToggleMute() {
+        let intent = touchIntent(
+            hitsPauseButton: false, hitsMuteButton: true, phase: .waitingToLaunch
+        )
+        #expect(intent == .toggleMute)
+    }
+
+    @Test func touchIntent_muteButton_whilePaused_returnsNone() {
+        let intent = touchIntent(hitsPauseButton: false, hitsMuteButton: true, phase: .paused)
+        #expect(intent == .none)
+    }
+
+    @Test func touchIntent_muteButton_whileGameOver_returnsNone() {
+        let intent = touchIntent(hitsPauseButton: false, hitsMuteButton: true, phase: .gameOver)
         #expect(intent == .none)
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `♪`/`✕` mute button to the HUD, positioned just inside the pause button (second from right)
- Tapping it toggles `SoundCoordinator.isMuted`, which persists to `UserDefaults` and controls `AVAudioEngine` mixer volume
- Mute state is reflected immediately on scene load (survives kill + relaunch)
- Toggle is active in `.playing` and `.waitingToLaunch` phases; ignored while paused or game over

## Changes

| File | Change |
|------|--------|
| `Theme.swift` | `Symbol.soundOn`/`soundOff`, `Layout.hudButtonSpacing` |
| `HUDNode` | `muteButton` label + `setMuted(_:)` |
| `GameCameraNode` | `updateMuteButton(isMuted:)` |
| `SoundCoordinator` | `toggleMute()` convenience |
| `TouchIntent` / `InputAction` / `InputCoordinator` | `.toggleMute` case + `hittingMuteButton` param |
| `GameScene` | wires toggle handler; seeds button state in `setupCamera` |
| `TouchIntentTests` | updated existing + 4 new mute cases |
| `InputCoordinatorTests` | updated existing + 2 new mute cases |

## Test plan

- [x] `scripts/build.sh` passes (lint + build + tests)
- [x] 332/334 tests pass (2 failures are pre-existing `SoundCoordinator` combo counter tests tracked in #83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)