### PR TITLE
fix: prevent mute button tap from firing lasers, closes #86

### DIFF
--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -192,13 +192,14 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         guard let touch = touches.first else { return }
         let loc = touch.location(in: self)
         let hitNodes = nodes(at: loc)
+        let hitHUD = hitNodes.contains { $0.name == "pauseButton" || $0.name == "muteButton" }
         handle(inputCoordinator.action(
             at: loc,
             hittingPauseButton: hitNodes.contains { $0.name == "pauseButton" },
             hittingMuteButton: hitNodes.contains { $0.name == "muteButton" },
             phase: gameState.phase
         ))
-        if gameState.phase == .playing { fireLasersIfActive() }
+        if gameState.phase == .playing && !hitHUD { fireLasersIfActive() }
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -192,14 +192,15 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         guard let touch = touches.first else { return }
         let loc = touch.location(in: self)
         let hitNodes = nodes(at: loc)
-        let hitHUD = hitNodes.contains { $0.name == "pauseButton" || $0.name == "muteButton" }
+        let hitPause = hitNodes.contains { $0.name == "pauseButton" }
+        let hitMute = hitNodes.contains { $0.name == "muteButton" }
         handle(inputCoordinator.action(
             at: loc,
-            hittingPauseButton: hitNodes.contains { $0.name == "pauseButton" },
-            hittingMuteButton: hitNodes.contains { $0.name == "muteButton" },
+            hittingPauseButton: hitPause,
+            hittingMuteButton: hitMute,
             phase: gameState.phase
         ))
-        if gameState.phase == .playing && !hitHUD { fireLasersIfActive() }
+        if gameState.phase == .playing && !(hitPause || hitMute) { fireLasersIfActive() }
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {


### PR DESCRIPTION
## Summary

- `fireLasersIfActive()` was gated only on `gameState.phase == .playing`, not on whether the touch hit a HUD button
- The mute button is the first non-phase-changing HUD action, making this newly observable: tapping ♪/✕ while the laser power-up was active would toggle mute **and** fire a laser
- Fix: compute `hitHUD` from the already-available `hitNodes` set and add `!hitHUD` to the laser guard

## Test plan

- [x] `scripts/build.sh` passes
- [x] 332/334 tests pass (2 pre-existing failures in #83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)