### PR TITLE
fix: seed audioLastHitTime to -.infinity, closes #83

### DIFF
--- a/Sources/Audio/SoundCoordinator.swift
+++ b/Sources/Audio/SoundCoordinator.swift
@@ -25,7 +25,7 @@ final class SoundCoordinator {
     // Audio-combo state for pitch boost (independent from scoring combo).
     // private(set) so @testable unit tests can read but not write the counter.
     private(set) var audioComboCounter = 0
-    private var audioLastHitTime: TimeInterval = 0
+    private var audioLastHitTime: TimeInterval = -.infinity
 
     private let defaults: UserDefaults
 


### PR DESCRIPTION
## Summary

- `audioLastHitTime` was initialised to `0`, so the first `updateAudioCombo(currentTime: 0.0)` call satisfied `0.0 - 0 < 0.15` and incremented the counter — putting all subsequent combo assertions off by one
- Seeding to `-.infinity` ensures the first call always falls outside the window and resets the counter, matching the intended semantics
- No behaviour change in production: `CACurrentMediaTime()` is always positive, so the first real hit at any wall-clock time is treated correctly as a fresh start

## Test plan

- [x] `scripts/build.sh` passes — all 334 tests green (previously 332)

🤖 Generated with [Claude Code](https://claude.com/claude-code)