### PR TITLE
refactor: rename hudButtonSpacing → muteButtonOffset, fix Theme.Symbol alignment, closes #87 #88

### DIFF
--- a/Sources/Constants/Theme.swift
+++ b/Sources/Constants/Theme.swift
@@ -59,7 +59,7 @@ enum Theme {
 
     enum Symbol {
         static let pause = "II"
-        static let soundOn  = "♪"
+        static let soundOn = "♪"
         static let soundOff = "✕"
     }
 
@@ -79,7 +79,7 @@ enum Theme {
         static let brickPoints: Int = 10
         static let hudTopPadding: CGFloat = 8
         static let hudSideMargin: CGFloat = 16
-        static let hudButtonSpacing: CGFloat = 36
+        static let muteButtonOffset: CGFloat = 36
         static let highScoreOffsetY: CGFloat = -30
         static let splashButtonSpacing: CGFloat = 44
         static let powerUpSize: CGSize = CGSize(width: 34, height: 14)

--- a/Sources/Nodes/HUDNode.swift
+++ b/Sources/Nodes/HUDNode.swift
@@ -25,7 +25,7 @@ final class HUDNode: SKNode {
         pauseButton.name = "pauseButton"
         muteButton.horizontalAlignmentMode = .right
         muteButton.position = CGPoint(
-            x: sceneSize.width / 2 - Theme.Layout.hudSideMargin - Theme.Layout.hudButtonSpacing,
+            x: sceneSize.width / 2 - Theme.Layout.hudSideMargin - Theme.Layout.muteButtonOffset,
             y: hudY
         )
         muteButton.name = "muteButton"


### PR DESCRIPTION
## Summary

- `Theme.Layout.hudButtonSpacing` → `muteButtonOffset`: the name now reflects what it actually offsets rather than a generic HUD concept (#87)
- `Theme.Symbol.soundOn`: removed spurious extra space before `=` to match `soundOff` alignment (#88)

## Test plan

- [x] `scripts/build.sh` passes — all 334 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)