### PR TITLE
fix: remove double game_over sound from GameScene.handleBallLoss

### DIFF
--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -330,7 +330,6 @@ private extension GameScene {
 
         // Scene transition (happens last)
         if isGameOver {
-            sound.playGameOver()
             persistence.gameOver()
             present(GameSummaryScene(size: size, outcome: .gameOver, score: gameState.score))
         } else {


### PR DESCRIPTION
## Summary

- Removes `sound.playGameOver()` from `GameScene.handleBallLoss()`
- `GameSummaryScene` already plays `game_over` on `didMove`; the call in `handleBallLoss` was truncated by the 0.4s fade transition, causing an audible ghost blip before the full sound played again

## Test plan

- [ ] Lose last ball → no truncated blip; `GameSummaryScene` plays the full `game_over` sound
- [ ] `scripts/build.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)