### PR TITLE
fix: disable AVAudioEngine auto-shutdown on macOS (#94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Package.swift
 build/
 .build/
 DerivedData/
+.derived-data-mac/
 xcuserdata/
 *.xcuserdatad/
 

--- a/Sources/Audio/SoundCoordinator.swift
+++ b/Sources/Audio/SoundCoordinator.swift
@@ -52,13 +52,10 @@ final class SoundCoordinator {
         self.brickPitchUnits = (0..<4).map { _ in AVAudioUnitTimePitch() }
         activateAudioSession()
         buildAudioGraph()
-        do {
-            try engine.start()
-        } catch {
-            print("SoundCoordinator: engine failed to start – \(error)")
-        }
+        startEngine()
         engine.mainMixerNode.outputVolume = defaults.bool(forKey: Self.muteKey) ? 0 : 1
         loadBuffers()
+        observeEngineConfigurationChange()
     }
 
     var isMuted: Bool {
@@ -208,6 +205,34 @@ final class SoundCoordinator {
 
     private func playActivateBuffer() {
         play(buffer: powerUpActivateBuffer, on: powerUpActivateNode)
+    }
+
+    private func startEngine() {
+        // macOS: disable auto-shutdown so the audio hardware stays active between
+        // sounds. The default is true on macOS (false on iOS), and the hardware
+        // wake-up latency races against the first scheduled buffer, causing all
+        // audio to be silently dropped.
+        #if os(macOS)
+        engine.isAutoShutdownEnabled = false
+        #endif
+        do {
+            try engine.start()
+        } catch {
+            print("SoundCoordinator: engine failed to start – \(error)")
+        }
+    }
+
+    private func observeEngineConfigurationChange() {
+        // On macOS, plugging/unplugging audio devices invalidates the engine's
+        // graph. Restart the engine when this happens so playback resumes.
+        NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.startEngine()
+        }
     }
 
     private func activateAudioSession() {

--- a/Sources/Audio/SoundCoordinator.swift
+++ b/Sources/Audio/SoundCoordinator.swift
@@ -245,23 +245,33 @@ final class SoundCoordinator {
 
     private func buildAudioGraph() {
         let mixer = engine.mainMixerNode
+        // Use the buffer format explicitly: mono float32 44100 Hz.
+        // On macOS, format: nil defaults to the hardware stereo output format,
+        // which causes a channel-count mismatch crash when mono buffers are
+        // scheduled. iOS silently converts; macOS does not.
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 44100,
+            channels: 1,
+            interleaved: false
+        )
 
         for idx in 0..<4 {
             engine.attach(brickHitNodes[idx])
             engine.attach(brickPitchUnits[idx])
-            engine.connect(brickHitNodes[idx], to: brickPitchUnits[idx], format: nil)
-            engine.connect(brickPitchUnits[idx], to: mixer, format: nil)
+            engine.connect(brickHitNodes[idx], to: brickPitchUnits[idx], format: format)
+            engine.connect(brickPitchUnits[idx], to: mixer, format: format)
         }
 
         [paddleNode, wallNode, launchNode, sfxNode, powerUpNode, powerUpCollectNode].forEach {
             engine.attach($0)
-            engine.connect($0, to: mixer, format: nil)
+            engine.connect($0, to: mixer, format: format)
         }
 
         engine.attach(powerUpActivateNode)
         engine.attach(powerUpActivatePitch)
-        engine.connect(powerUpActivateNode, to: powerUpActivatePitch, format: nil)
-        engine.connect(powerUpActivatePitch, to: mixer, format: nil)
+        engine.connect(powerUpActivateNode, to: powerUpActivatePitch, format: format)
+        engine.connect(powerUpActivatePitch, to: mixer, format: format)
     }
 
     private func loadBuffers() {

--- a/scripts/run-mac.sh
+++ b/scripts/run-mac.sh
@@ -3,19 +3,20 @@ set -euo pipefail
 
 SCHEME="BreakoutGameMac"
 PROJECT="BreakoutGame.xcodeproj"
+DERIVED_DATA="$(pwd)/.derived-data-mac"
 
 echo "==> Building $SCHEME..."
 xcodebuild -project "$PROJECT" \
   -scheme "$SCHEME" \
   -destination "platform=macOS" \
   -configuration Debug \
+  -derivedDataPath "$DERIVED_DATA" \
   build | xcpretty 2>/dev/null || true
 
-APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "BreakoutGameMac.app" \
-  -path "*/Debug/*" | head -1)
+APP_PATH="$DERIVED_DATA/Build/Products/Debug/BreakoutGameMac.app"
 
-if [[ -z "$APP_PATH" ]]; then
-  echo "Error: could not find BreakoutGameMac.app in DerivedData" >&2
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "Error: could not find $APP_PATH" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Root cause

`engine.connect(node:to:format:nil)` on macOS defaults the connection format to the **hardware stereo output format** (2 channels). When the mono `.caf` buffers are then scheduled, `AVAudioEngine` throws:

> `required condition is false: _outputFormat.channelCount == buffer.format.channelCount`

iOS silently converts mono→stereo; macOS does not — it crashes.

## Summary

- Pass an explicit `AVAudioFormat(float32, 44100 Hz, mono)` for all player-node connections so the format matches the loaded `.caf` buffers. `AVAudioMixerNode` handles the mono→stereo upsampling to hardware output.
- Also sets `engine.isAutoShutdownEnabled = false` on macOS (the engine otherwise shuts down audio hardware when idle, which could drop the first sound after a period of silence).
- Adds an `AVAudioEngineConfigurationChange` observer to restart the engine on device change (headphones plug/unplug).

## Test plan

- [ ] Build and run the macOS target (`BreakoutGameMac`)
- [ ] Confirm brick hits, paddle hits, wall hits, and ball launch all produce sound
- [ ] Confirm lifecycle sounds (level complete, game over, ball loss) play
- [ ] Confirm power-up collect/activate/expire sounds play
- [ ] Confirm mute toggle works on macOS
- [ ] iOS build still passes all tests (confirmed locally)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)