### PR TITLE
fix: re-hide cursor after macOS fullscreen menu bar reveals it

### DIFF
--- a/Sources/AppDelegateMac.swift
+++ b/Sources/AppDelegateMac.swift
@@ -58,6 +58,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidBecomeActive(_ notification: Notification) {
         if window.isKeyWindow {
             if let scene = skView.scene, scene is GameScene {
+                // Reset flag before hiding: macOS may have called NSCursor.unhide()
+                // internally (e.g. for the fullscreen menu bar), leaving cursorHidden
+                // stale at true while the cursor is actually visible.
+                cursorHidden = false
                 hideCursor()
             }
         }
@@ -92,6 +96,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 extension AppDelegate: NSWindowDelegate {
     func windowDidBecomeKey(_ notification: Notification) {
+        if skView.scene is GameScene {
+            cursorHidden = false
+            hideCursor()
+        }
         guard !didEnterFullScreen else { return }
         didEnterFullScreen = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in

--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -24,6 +24,7 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     private let inputCoordinator = InputCoordinator()
     #if os(macOS)
     private let mouseTracker = MouseInputTracker()
+    private var mouseMovedMonitor: Any?
     #endif
 
     init(
@@ -53,6 +54,10 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
         #if os(macOS)
         mouseTracker.install(on: view)
         (NSApp.delegate as? AppDelegate)?.hideCursor()
+        mouseMovedMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { event in
+            (NSApp.delegate as? AppDelegate)?.hideCursor()
+            return event
+        }
         #endif
     }
 
@@ -280,6 +285,10 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
     override func willMove(from view: SKView) {
         #if os(macOS)
         mouseTracker.uninstall(from: view)
+        if let monitor = mouseMovedMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseMovedMonitor = nil
+        }
         #endif
         sound.stopEngine()
         persistence.sceneWillDisappear(


### PR DESCRIPTION
Closes #92.

## Root cause

`NSCursor.hide()`/`unhide()` is reference-counted by the OS. When the
fullscreen menu bar appears, macOS calls `NSCursor.unhide()` internally,
dropping the ref count to 0 (cursor visible). Our `cursorHidden` flag
stays `true` (stale). Any subsequent `hideCursor()` call hits the guard
and exits early — cursor stays visible for the rest of the session.

## Fix

Three layers:

1. **`applicationDidBecomeActive`** — reset `cursorHidden = false` before
   calling `hideCursor()`. When the app loses and regains focus (e.g.
   Cmd+Tab, or the menu bar interaction causes an active/resign cycle),
   this ensures the re-hide actually reaches `NSCursor.hide()`.

2. **`windowDidBecomeKey`** — same reset before the `didEnterFullScreen`
   guard. Covers the case where the window loses and regains key status
   (which macOS may trigger when the fullscreen menu bar appears).

3. **Local `mouseMoved` event monitor in `GameScene`** — belt-and-suspenders.
   Calls `hideCursor()` on every mouse movement during gameplay. If the
   flag was reset to `false` by either of the above, the next mouse move
   re-hides the cursor without waiting for another activation event.

## Test plan

- [ ] Start a level in fullscreen
- [ ] Move mouse to top of screen to trigger the menu bar
- [ ] Move mouse back into play area — cursor should disappear
- [ ] Repeat several times — cursor should always hide on return
- [ ] Cmd+Tab away and back — cursor should re-hide when gameplay resumes
- [ ] Pause and resume — cursor behaviour unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)