### PR TITLE
fix: replace mute SKLabelNode with SF Symbol SKSpriteNode

### DIFF
--- a/Sources/Constants/Theme.swift
+++ b/Sources/Constants/Theme.swift
@@ -59,8 +59,6 @@ enum Theme {
 
     enum Symbol {
         static let pause = "II"
-        static let soundOn = "♪"
-        static let soundOff = "✕"
     }
 
     enum Layout {

--- a/Sources/Nodes/HUDNode.swift
+++ b/Sources/Nodes/HUDNode.swift
@@ -1,10 +1,15 @@
 import SpriteKit
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
 
 final class HUDNode: SKNode {
     private let livesLabel: SKLabelNode
     private let scoreLabel: SKLabelNode
     private let pauseButton: SKLabelNode
-    private let muteButton: SKLabelNode
+    private let muteButton: SKSpriteNode
     private let comboLabel: SKLabelNode
     private var lastScore: Int = 0
     private var lastComboMultiplier: Int = 1
@@ -13,7 +18,7 @@ final class HUDNode: SKNode {
         livesLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         scoreLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         pauseButton = SKLabelNode.makeBody(Theme.Symbol.pause, color: Theme.Color.primary)
-        muteButton = SKLabelNode.makeBody(Theme.Symbol.soundOn, color: Theme.Color.primary)
+        muteButton = SKSpriteNode(texture: HUDNode.muteTexture(muted: false))
         comboLabel = SKLabelNode.makeBody("", color: Theme.Color.danger)
         super.init()
         let hudY = sceneSize.height / 2 - topSafeArea - Theme.Layout.hudTopPadding
@@ -23,7 +28,8 @@ final class HUDNode: SKNode {
         pauseButton.horizontalAlignmentMode = .right
         pauseButton.position = CGPoint(x: sceneSize.width / 2 - Theme.Layout.hudSideMargin, y: hudY)
         pauseButton.name = "pauseButton"
-        muteButton.horizontalAlignmentMode = .right
+        muteButton.color = Theme.Color.primary
+        muteButton.colorBlendFactor = 1
         muteButton.position = CGPoint(
             x: sceneSize.width / 2 - Theme.Layout.hudSideMargin - Theme.Layout.muteButtonOffset,
             y: hudY
@@ -40,7 +46,20 @@ final class HUDNode: SKNode {
     }
 
     func setMuted(_ muted: Bool) {
-        muteButton.text = muted ? Theme.Symbol.soundOff : Theme.Symbol.soundOn
+        muteButton.texture = HUDNode.muteTexture(muted: muted)
+    }
+
+    private static func muteTexture(muted: Bool) -> SKTexture {
+        let symbolName = muted ? "speaker.slash" : "speaker.wave.2"
+        #if canImport(UIKit)
+        let config = UIImage.SymbolConfiguration(pointSize: Theme.FontSize.small, weight: .regular)
+        // swiftlint:disable:next force_unwrapping
+        let image = UIImage(systemName: symbolName, withConfiguration: config)!
+        #else
+        // swiftlint:disable:next force_unwrapping
+        let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)!
+        #endif
+        return SKTexture(image: image)
     }
 
     func update(lives: Int, score: Int, comboMultiplier: Int = 1) {

--- a/Sources/Nodes/HUDNode.swift
+++ b/Sources/Nodes/HUDNode.swift
@@ -18,7 +18,7 @@ final class HUDNode: SKNode {
         livesLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         scoreLabel = SKLabelNode.makeBody("", color: Theme.Color.accent)
         pauseButton = SKLabelNode.makeBody(Theme.Symbol.pause, color: Theme.Color.primary)
-        muteButton = SKSpriteNode(texture: HUDNode.muteTexture(muted: false))
+        muteButton = SKSpriteNode(texture: HUDNode.textureUnmuted)
         comboLabel = SKLabelNode.makeBody("", color: Theme.Color.danger)
         super.init()
         let hudY = sceneSize.height / 2 - topSafeArea - Theme.Layout.hudTopPadding
@@ -46,21 +46,32 @@ final class HUDNode: SKNode {
     }
 
     func setMuted(_ muted: Bool) {
-        muteButton.texture = HUDNode.muteTexture(muted: muted)
+        muteButton.texture = muted ? HUDNode.textureMuted : HUDNode.textureUnmuted
     }
 
-    private static func muteTexture(muted: Bool) -> SKTexture {
-        let symbolName = muted ? "speaker.slash" : "speaker.wave.2"
+    private static let textureUnmuted: SKTexture = {
         #if canImport(UIKit)
         let config = UIImage.SymbolConfiguration(pointSize: Theme.FontSize.small, weight: .regular)
         // swiftlint:disable:next force_unwrapping
-        let image = UIImage(systemName: symbolName, withConfiguration: config)!
+        let image = UIImage(systemName: "speaker.wave.2", withConfiguration: config)!
         #else
         // swiftlint:disable:next force_unwrapping
-        let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)!
+        let image = NSImage(systemSymbolName: "speaker.wave.2", accessibilityDescription: nil)!
         #endif
         return SKTexture(image: image)
-    }
+    }()
+
+    private static let textureMuted: SKTexture = {
+        #if canImport(UIKit)
+        let config = UIImage.SymbolConfiguration(pointSize: Theme.FontSize.small, weight: .regular)
+        // swiftlint:disable:next force_unwrapping
+        let image = UIImage(systemName: "speaker.slash", withConfiguration: config)!
+        #else
+        // swiftlint:disable:next force_unwrapping
+        let image = NSImage(systemSymbolName: "speaker.slash", accessibilityDescription: nil)!
+        #endif
+        return SKTexture(image: image)
+    }()
 
     func update(lives: Int, score: Int, comboMultiplier: Int = 1) {
         livesLabel.text = livesText(lives)


### PR DESCRIPTION
## Summary

- Replaces the invisible `SKLabelNode` mute button (♪/✕ characters not in AvenirNext's glyph set) with an `SKSpriteNode` backed by SF Symbols (`speaker.wave.2` / `speaker.slash`)
- Tinted to `Theme.Color.primary` via `.color` + `.colorBlendFactor = 1` to match the rest of the HUD
- `setMuted(_:)` now swaps textures instead of setting label text
- Removes unused `Theme.Symbol.soundOn` and `Theme.Symbol.soundOff`
- macOS target handled via `#if canImport(UIKit)` / `#else` with `NSImage(systemSymbolName:)`

Closes #93

## Test plan
- [ ] Mute button is visible in `.waitingToLaunch` and `.playing` phases
- [ ] Icon toggles between speaker-on and speaker-off when tapped
- [ ] Icon is tinted to match pause button colour
- [ ] Touch target unchanged (same position/size as before)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)