### PR TITLE
fix: mute button HUD alignment and M keyboard shortcut (macOS)

### DIFF
--- a/Sources/Constants/Theme.swift
+++ b/Sources/Constants/Theme.swift
@@ -78,6 +78,7 @@ enum Theme {
         static let hudTopPadding: CGFloat = 8
         static let hudSideMargin: CGFloat = 16
         static let muteButtonOffset: CGFloat = 36
+        static let muteButtonAlignmentOffset: CGFloat = 6
         static let highScoreOffsetY: CGFloat = -30
         static let splashButtonSpacing: CGFloat = 44
         static let powerUpSize: CGSize = CGSize(width: 34, height: 14)

--- a/Sources/Nodes/HUDNode.swift
+++ b/Sources/Nodes/HUDNode.swift
@@ -30,7 +30,7 @@ final class HUDNode: SKNode {
         pauseButton.name = "pauseButton"
         muteButton.position = CGPoint(
             x: sceneSize.width / 2 - Theme.Layout.hudSideMargin - Theme.Layout.muteButtonOffset,
-            y: hudY
+            y: hudY + Theme.Layout.muteButtonAlignmentOffset
         )
         muteButton.name = "muteButton"
         // Combo label sits below the score, hidden while multiplier is ×1

--- a/Sources/Scenes/GameScene.swift
+++ b/Sources/Scenes/GameScene.swift
@@ -243,6 +243,8 @@ final class GameScene: SKScene, SKPhysicsContactDelegate {
             case .paused:  handle(.resume)
             default:       break
             }
+        case "m" where gameState.phase == .playing || gameState.phase == .waitingToLaunch:
+            handle(.toggleMute)
         case " " where gameState.phase == .playing:
             fireLasersIfActive()
         #if DEBUG


### PR DESCRIPTION
## Summary

- Raises the mute `SKSpriteNode` by `muteButtonAlignmentOffset` (6 pt) so its visual centre aligns with the `SKLabelNode` pause button baseline — closes #103
- Adds `M` key to toggle mute on macOS during `.playing` / `.waitingToLaunch`, consistent with touch behaviour — closes #105

## Changes

- `Theme.Layout.muteButtonAlignmentOffset: CGFloat = 6` — named constant for the baseline correction
- `HUDNode`: applies the offset to `muteButton.position.y`
- `GameScene.keyDown`: adds `"m"` case, guarded to `.playing` / `.waitingToLaunch` only

## Test plan

- [ ] Launch game in macOS simulator — verify mute icon is visually level with the pause "II" button
- [ ] Press \`M\` while game is running — icon toggles, audio mutes/unmutes
- [ ] Press \`M\` while waiting to launch — same
- [ ] Press \`M\` while paused or game-over — no effect
- [ ] All existing tests pass (\`scripts/build.sh\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)