### PR TITLE
docs: scaffold GitHub Pages site with Jekyll + Mermaid

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD033": {
+    "allowed_elements": ["pre"]
+  }
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,7 @@
+title: Breakout Game
+description: iOS/macOS breakout game built with Swift + SpriteKit
+theme: minima
+markdown: kramdown
+
+minima:
+  skin: dark

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,4 @@
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'dark' });
+</script>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,105 @@
+---
+title: Architecture
+layout: page
+---
+
+The codebase follows the **Functional Core / Imperative Shell** pattern:
+
+- **Functional core** — plain Swift types with no SpriteKit dependency. State
+  transitions return new values; nothing mutates in place. Fully unit-tested.
+- **Imperative shell** — SpriteKit scenes and nodes that own the mutable world.
+  They call into the core to decide *what* should happen, then apply those
+  decisions as mutations.
+
+The discipline is: *calculate first, mutate after.*
+
+---
+
+## Component Map
+
+<pre class="mermaid">
+graph TB
+    subgraph Shell["Imperative Shell · SpriteKit"]
+        subgraph Scenes["Scenes"]
+            SplashScene
+            GameScene
+            GameSummaryScene
+            MacLaunchSplashScene
+        end
+        subgraph Nodes["Nodes"]
+            BallNode
+            PaddleNode
+            BrickNode
+            HUDNode
+            PowerUpNode
+            BackdropNode
+        end
+    end
+
+    subgraph Core["Functional Core · Plain Swift"]
+        subgraph State["State"]
+            GameState
+            GamePhase
+            PowerUpState
+        end
+        subgraph Logic["Logic"]
+            GameLoopCoordinator
+            ContactCoordinator
+            PowerUpCoordinator
+            ComboTracker
+        end
+        subgraph Data["Data & Levels"]
+            Level
+            BrickCell
+            SavedGame
+        end
+    end
+
+    subgraph Platform["Platform Layer"]
+        SoundCoordinator
+        InputCoordinator
+        GamePersistenceCoordinator
+        GameSaveStore
+        HighScoreStore
+    end
+
+    GameScene --> Core
+    GameScene --> Platform
+    GameScene --> Nodes
+    SplashScene -->|"new game"| GameScene
+    GameScene -->|"game over / victory"| GameSummaryScene
+    GameSummaryScene -->|"play again"| SplashScene
+</pre>
+
+---
+
+## Scene Flow
+
+<pre class="mermaid">
+flowchart LR
+    SplashScene -->|"tap Play"| GameScene
+    GameScene -->|"all levels cleared"| GS_Victory["GameSummaryScene\n(victory)"]
+    GameScene -->|"lives = 0"| GS_GameOver["GameSummaryScene\n(game over)"]
+    GS_Victory -->|"play again"| SplashScene
+    GS_GameOver -->|"play again"| SplashScene
+</pre>
+
+---
+
+## Game State Machine
+
+`GameScene` owns a `GameState` value that drives gameplay flow.
+All transitions are pure functions — they return a new `GameState` rather than
+mutating the existing one.
+
+<pre class="mermaid">
+stateDiagram-v2
+    [*] --> WaitingToLaunch
+    WaitingToLaunch --> Playing : launch ball
+    Playing --> WaitingToLaunch : ball lost, lives > 0
+    Playing --> GameOver : ball lost, lives = 0
+    Playing --> Paused : pause
+    Paused --> Playing : resume
+    Playing --> [*] : level cleared → next level / victory
+    GameOver --> [*]
+</pre>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+---
+title: Home
+layout: home
+---
+
+A breakout game for iOS and macOS, built with Swift + SpriteKit.
+
+## Pages
+
+- [Architecture](architecture) — component map, scene flow, and game state machine


### PR DESCRIPTION
## Summary
- Adds a `/docs` folder to serve via GitHub Pages (Jekyll, minima dark skin)
- Mermaid.js loaded from CDN via `_includes/head-custom.html` — no plugins needed
- Architecture page with three diagrams: component map, scene flow, game state machine
- `docs/.markdownlint.json` allows `<pre>` elements (required for Mermaid blocks)

## To activate GitHub Pages
Go to **Settings → Pages**, set source to **Deploy from branch**, branch `main`, folder `/docs`.

## Test plan
- [ ] Enable Pages in repo settings as above
- [ ] Visit the published URL and confirm Mermaid diagrams render

🤖 Generated with [Claude Code](https://claude.ai/claude-code)