### PR TITLE
fix: switch Mermaid to UMD build for GitHub Pages compatibility

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,4 +1,2 @@
-<script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-  mermaid.initialize({ startOnLoad: true, theme: 'dark' });
-</script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>


### PR DESCRIPTION
## Problem
The ES module (`type="module"`) import of Mermaid was failing silently on GitHub Pages, causing diagrams to render as raw text.

## Fix
Switch to the UMD build via a plain `<script>` tag in `_includes/head-custom.html`. This is more compatible with how minima injects the include and avoids any module resolution issues.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)