### PR TITLE
fix: inline Mermaid script directly in architecture page

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,5 +1,5 @@
 {
   "MD033": {
-    "allowed_elements": ["pre", "small"]
+    "allowed_elements": ["pre", "small", "script"]
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,3 +105,6 @@ stateDiagram-v2
     Playing --> [*] : level cleared → next level / victory
     GameOver --> [*]
 </pre>
+
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>


### PR DESCRIPTION
## Problem
`head-custom.html` is silently ignored by the minima version GitHub Pages uses — confirmed by fetching the rendered HTML and seeing no `<script>` tag for Mermaid.

## Fix
Inject the Mermaid `<script>` tags directly at the bottom of `architecture.md`. Jekyll passes raw HTML blocks through unchanged, so this is guaranteed to work regardless of theme behaviour.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)