### PR TITLE
feat: 100-level architecture with worlds, boss flags, and LevelMetadata

### DIFF
--- a/Sources/Data/LevelData.swift
+++ b/Sources/Data/LevelData.swift
@@ -1,0 +1,104 @@
+private let e: BrickCell = .empty
+private let n: BrickCell = .normal
+private let i: BrickCell = .indestructible
+private let b: BrickCell = .bonus
+private func m(_ hits: Int) -> BrickCell { .multiHit(hits) }
+
+// MARK: - Hand-crafted levels (1–5)
+
+private let levelOneGrid: [[BrickCell]] = [
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, b, b, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n]
+]
+
+private let levelTwoGrid: [[BrickCell]] = [
+    [n, e, n, e, n, e, n, e, n, e],
+    [e, n, e, n, e, n, e, n, e, n],
+    [n, e, n, e, n, e, n, e, n, e],
+    [e, n, e, n, e, n, e, n, e, n],
+    [n, e, n, e, n, e, n, e, n, e],
+    [e, n, e, n, e, n, e, n, e, n],
+    [n, e, n, e, n, e, n, e, n, e],
+    [e, n, e, n, e, n, e, n, e, n]
+]
+
+private let levelThreeGrid: [[BrickCell]] = [
+    [e, e, e, e, b, b, e, e, e, e],
+    [e, e, e, n, n, n, n, e, e, e],
+    [e, e, n, n, n, n, n, n, e, e],
+    [e, n, n, n, n, n, n, n, n, e],
+    [n, n, n, n, m(3), m(3), n, n, n, n],
+    [e, n, n, n, n, n, n, n, n, e],
+    [e, e, n, n, n, n, n, n, e, e],
+    [e, e, e, n, n, n, n, e, e, e],
+    [e, e, e, e, b, b, e, e, e, e]
+]
+
+private let levelFourGrid: [[BrickCell]] = [
+    [m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2)],
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n],
+    [n, n, n, n, n, n, n, n, n, n]
+]
+
+private let levelFiveGrid: [[BrickCell]] = [
+    [n, n, n, i, i, i, i, n, n, n],
+    [n, e, e, e, e, e, e, e, e, n],
+    [n, e, n, n, e, e, n, n, e, n],
+    [i, e, n, e, n, n, e, n, e, i],
+    [i, e, n, e, m(2), m(2), e, n, e, i],
+    [i, e, n, e, m(2), m(2), e, n, e, i],
+    [i, e, n, e, n, n, e, n, e, i],
+    [n, e, n, n, e, e, n, n, e, n],
+    [n, e, e, e, e, e, e, e, e, n],
+    [n, n, n, i, i, i, i, n, n, n]
+]
+
+// MARK: - Programmatic stub generator
+
+/// Generates a simple placeholder grid for levels that have not yet been hand-crafted.
+/// The pattern varies by level index so each level looks slightly different.
+private func stubGrid(levelIndex: Int) -> [[BrickCell]] {
+    let rows = min(4 + (levelIndex / 10), 10)
+    return (0..<rows).map { row in
+        (0..<10).map { col in
+            let isBossRow = (levelIndex + 1) % 10 == 0
+            if isBossRow && row == 0 { return m(3) }
+            if (row + col + levelIndex) % 5 == 0 { return e }
+            if (row + col) % 7 == 0 { return b }
+            if isBossRow && (row + col) % 4 == 0 { return i }
+            return n
+        }
+    }
+}
+
+// MARK: - All 100 levels
+
+let allLevelGrids: [(name: String, grid: [[BrickCell]])] = {
+    var levels: [(name: String, grid: [[BrickCell]])] = []
+
+    // Hand-crafted levels 1–5
+    levels.append(("ROOKIE", levelOneGrid))
+    levels.append(("HOTSHOT", levelTwoGrid))
+    levels.append(("ACE", levelThreeGrid))
+    levels.append(("LEGEND", levelFourGrid))
+    levels.append(("MAZE", levelFiveGrid))
+
+    // Programmatic stubs for levels 6–100
+    for idx in 5..<100 {
+        let number = idx + 1
+        let world = (idx / 10) + 1
+        let positionInWorld = (idx % 10) + 1
+        let isBoss = positionInWorld == 10
+        let name = isBoss ? "WORLD \(world) BOSS" : "LEVEL \(number)"
+        levels.append((name, stubGrid(levelIndex: idx)))
+    }
+
+    return levels
+}()

--- a/Sources/Data/LevelData.swift
+++ b/Sources/Data/LevelData.swift
@@ -66,13 +66,13 @@ private let levelFiveGrid: [[BrickCell]] = [
 /// The pattern varies by level index so each level looks slightly different.
 private func stubGrid(levelIndex: Int) -> [[BrickCell]] {
     let rows = min(4 + (levelIndex / 10), 10)
+    let isBoss = (levelIndex + 1) % 10 == 0
     return (0..<rows).map { row in
         (0..<10).map { col in
-            let isBossRow = (levelIndex + 1) % 10 == 0
-            if isBossRow && row == 0 { return m(3) }
+            if isBoss && row == 0 { return m(3) }
             if (row + col + levelIndex) % 5 == 0 { return e }
             if (row + col) % 7 == 0 { return b }
-            if isBossRow && (row + col) % 4 == 0 { return i }
+            if isBoss && (row + col) % 4 == 0 { return i }
             return n
         }
     }

--- a/Sources/Logic/Level.swift
+++ b/Sources/Logic/Level.swift
@@ -1,9 +1,4 @@
-struct LevelMetadata {
-    // Fields populated by consuming issues:
-    // #114 — ball speed scaling
-    // #57  — boss phase count
-    // #power-up drop rate extension
-}
+struct LevelMetadata {}
 
 struct Level {
     let name: String
@@ -19,7 +14,6 @@ struct Level {
     var world: Int { (levelIndex / 10) + 1 }
     var indexInWorld: Int { (levelIndex % 10) + 1 }
     var isBoss: Bool { indexInWorld == 10 }
-    var metadata: LevelMetadata { LevelMetadata() }
 
     var brickCount: Int {
         grid.flatMap { $0 }.filter { $0 != .empty && $0 != .indestructible }.count

--- a/Sources/Logic/Level.swift
+++ b/Sources/Logic/Level.swift
@@ -1,75 +1,31 @@
-private let e: BrickCell = .empty
-private let n: BrickCell = .normal
-private let i: BrickCell = .indestructible
-private let b: BrickCell = .bonus
-private func m(_ hits: Int) -> BrickCell { .multiHit(hits) }
+struct LevelMetadata {
+    // Fields populated by consuming issues:
+    // #114 — ball speed scaling
+    // #57  — boss phase count
+    // #power-up drop rate extension
+}
 
 struct Level {
     let name: String
     let grid: [[BrickCell]]
+    let levelIndex: Int
+
+    init(name: String, grid: [[BrickCell]], levelIndex: Int = 0) {
+        self.name = name
+        self.grid = grid
+        self.levelIndex = levelIndex
+    }
+
+    var world: Int { (levelIndex / 10) + 1 }
+    var indexInWorld: Int { (levelIndex % 10) + 1 }
+    var isBoss: Bool { indexInWorld == 10 }
+    var metadata: LevelMetadata { LevelMetadata() }
 
     var brickCount: Int {
         grid.flatMap { $0 }.filter { $0 != .empty && $0 != .indestructible }.count
     }
 
-    // 5 rows × 10 columns, fully packed — 48 normal + 2 bonus = 50 bricks
-    static let one = Level(name: "ROOKIE", grid: [
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, b, b, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n]
-    ])
-
-    // 8 rows × 10 columns, checkerboard — 40 bricks
-    static let two = Level(name: "HOTSHOT", grid: [
-        [n, e, n, e, n, e, n, e, n, e],
-        [e, n, e, n, e, n, e, n, e, n],
-        [n, e, n, e, n, e, n, e, n, e],
-        [e, n, e, n, e, n, e, n, e, n],
-        [n, e, n, e, n, e, n, e, n, e],
-        [e, n, e, n, e, n, e, n, e, n],
-        [n, e, n, e, n, e, n, e, n, e],
-        [e, n, e, n, e, n, e, n, e, n]
-    ])
-
-    // 9 rows × 10 columns, diamond — 2 bonus at each tip, center row has 3-hit bricks — 50 bricks
-    static let three = Level(name: "ACE", grid: [
-        [e, e, e, e, b, b, e, e, e, e],
-        [e, e, e, n, n, n, n, e, e, e],
-        [e, e, n, n, n, n, n, n, e, e],
-        [e, n, n, n, n, n, n, n, n, e],
-        [n, n, n, n, m(3), m(3), n, n, n, n],
-        [e, n, n, n, n, n, n, n, n, e],
-        [e, e, n, n, n, n, n, n, e, e],
-        [e, e, e, n, n, n, n, e, e, e],
-        [e, e, e, e, b, b, e, e, e, e]
-    ])
-
-    // 7 rows × 10 columns, fully packed — top row has 2-hit bricks — 70 bricks total
-    static let four = Level(name: "LEGEND", grid: [
-        [m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2), m(2)],
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n],
-        [n, n, n, n, n, n, n, n, n, n]
-    ])
-
-    // 10 rows × 10 columns, symmetric labyrinth — 44 bricks
-    static let five = Level(name: "MAZE", grid: [
-        [n, n, n, i, i, i, i, n, n, n],
-        [n, e, e, e, e, e, e, e, e, n],
-        [n, e, n, n, e, e, n, n, e, n],
-        [i, e, n, e, n, n, e, n, e, i],
-        [i, e, n, e, m(2), m(2), e, n, e, i],
-        [i, e, n, e, m(2), m(2), e, n, e, i],
-        [i, e, n, e, n, n, e, n, e, i],
-        [n, e, n, n, e, e, n, n, e, n],
-        [n, e, e, e, e, e, e, e, e, n],
-        [n, n, n, i, i, i, i, n, n, n]
-    ])
-
-    static let all: [Level] = [.one, .two, .three, .four, .five]
+    static let all: [Level] = allLevelGrids.enumerated().map { idx, entry in
+        Level(name: entry.name, grid: entry.grid, levelIndex: idx)
+    }
 }

--- a/Tests/LevelCatalogueTests.swift
+++ b/Tests/LevelCatalogueTests.swift
@@ -34,13 +34,6 @@ struct LevelCatalogueTests {
         #expect(Level.all[4].name == "MAZE")
     }
 
-    @Test func bossLevelsAtEveryTenthIndex() {
-        for world in 1...10 {
-            let idx = world * 10 - 1
-            #expect(Level.all[idx].isBoss == true)
-        }
-    }
-
     @Test func nonBossLevelsAreNotBoss() {
         for (idx, level) in Level.all.enumerated() {
             let expectedBoss = (idx + 1) % 10 == 0

--- a/Tests/LevelCatalogueTests.swift
+++ b/Tests/LevelCatalogueTests.swift
@@ -2,8 +2,8 @@
 import Testing
 
 struct LevelCatalogueTests {
-    @Test func catalogueContainsFiveLevels() {
-        #expect(Level.all.count == 5)
+    @Test func catalogueContainsOneHundredLevels() {
+        #expect(Level.all.count == 100)
     }
 
     @Test func allLevelsHaveAtLeastOneBrick() {
@@ -26,8 +26,45 @@ struct LevelCatalogueTests {
         #expect(Set(names).count == names.count)
     }
 
-    @Test func levelNamesMatchArcadeTheme() {
-        let names = Level.all.map(\.name)
-        #expect(names == ["ROOKIE", "HOTSHOT", "ACE", "LEGEND", "MAZE"])
+    @Test func handCraftedLevelsPreserved() {
+        #expect(Level.all[0].name == "ROOKIE")
+        #expect(Level.all[1].name == "HOTSHOT")
+        #expect(Level.all[2].name == "ACE")
+        #expect(Level.all[3].name == "LEGEND")
+        #expect(Level.all[4].name == "MAZE")
+    }
+
+    @Test func bossLevelsAtEveryTenthIndex() {
+        for world in 1...10 {
+            let idx = world * 10 - 1
+            #expect(Level.all[idx].isBoss == true)
+        }
+    }
+
+    @Test func nonBossLevelsAreNotBoss() {
+        for (idx, level) in Level.all.enumerated() {
+            let expectedBoss = (idx + 1) % 10 == 0
+            #expect(level.isBoss == expectedBoss)
+        }
+    }
+
+    @Test func worldComputedProperty() {
+        #expect(Level.all[0].world == 1)
+        #expect(Level.all[9].world == 1)
+        #expect(Level.all[10].world == 2)
+        #expect(Level.all[99].world == 10)
+    }
+
+    @Test func indexInWorldComputedProperty() {
+        #expect(Level.all[0].indexInWorld == 1)
+        #expect(Level.all[9].indexInWorld == 10)
+        #expect(Level.all[10].indexInWorld == 1)
+        #expect(Level.all[99].indexInWorld == 10)
+    }
+
+    @Test func levelIndexMatchesPosition() {
+        for (idx, level) in Level.all.enumerated() {
+            #expect(level.levelIndex == idx)
+        }
     }
 }

--- a/Tests/LevelTests.swift
+++ b/Tests/LevelTests.swift
@@ -3,8 +3,8 @@ import Testing
 
 struct LevelTests {
     @Test func brickCountFullGrid() {
-        // Level.one is 5 rows × 10 columns, 48 normal + 2 bonus → 50 bricks
-        #expect(Level.one.brickCount == 50)
+        // Level 1 (ROOKIE) is 5 rows × 10 columns, 48 normal + 2 bonus → 50 bricks
+        #expect(Level.all[0].brickCount == 50)
     }
 
     @Test func brickCountSparseGrid() {


### PR DESCRIPTION
## Summary

- Expands `Level.all` from 5 to 100 entries; levels 1–5 are the existing hand-crafted grids, levels 6–100 use programmatic stubs until individual levels are designed in follow-up issues
- Adds `world` (1–10), `indexInWorld` (1–10), and `isBoss` computed properties — every 10th level (indices 9, 19, …, 99) is a boss
- Adds empty `LevelMetadata` struct, ready for #114 (ball speed multiplier), #57 (boss phase count), and power-up drop rate extensions
- Moves all grid data to `Sources/Data/LevelData.swift`; `Level.swift` is now pure model logic
- `Level.init` gets a default `levelIndex: 0` so test helpers that construct ad-hoc `Level` values keep compiling without changes

## Acceptance criteria
- [x] `Level.all.count == 100`
- [x] `Level.all[9].isBoss == true`, `Level.all[19].isBoss == true`, …, `Level.all[99].isBoss == true`
- [x] `LevelMetadata` struct exists
- [x] Existing save/restore (`levelIndex: Int` in `SavedGame`) unaffected
- [x] Levels 1–5 (ROOKIE–MAZE) preserved

## Test plan
- `LevelCatalogueTests`: count == 100, boss flags, world/indexInWorld values, unique names, hand-crafted level names, levelIndex matches position
- `LevelTests`: brickCount tests updated to use `Level.all[0]` instead of removed `Level.one`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)