### PR TITLE
fix: MainActor.assumeIsolated for engine restart in notification closure

### DIFF
--- a/Sources/Audio/SoundCoordinator.swift
+++ b/Sources/Audio/SoundCoordinator.swift
@@ -231,7 +231,7 @@ final class SoundCoordinator {
             queue: .main
         ) { [weak self] _ in
             guard let self else { return }
-            self.startEngine()
+            MainActor.assumeIsolated { self.startEngine() }
         }
     }
 


### PR DESCRIPTION
## Summary

- `SoundCoordinator.observeEngineConfigurationChange` registers an `AVAudioEngineConfigurationChange` observer with `queue: .main`, so the closure always executes on the main thread
- Swift concurrency doesn't see the `queue:` argument as proof of main-actor isolation, causing a \"call to main actor-isolated instance method in a synchronous nonisolated context\" warning
- Replace the bare `self.startEngine()` call with `MainActor.assumeIsolated { self.startEngine() }` — asserts the known invariant without spawning a new `Task`

## Test plan
- [ ] Build succeeds with no Swift concurrency warnings in `SoundCoordinator.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)